### PR TITLE
Add aggregation modules for different scenarios.

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -6,6 +6,11 @@ mlbench_core.models
 pytorch
 ~~~~~~~
 
+Since `Kuang Liu<https://github.com/kuangliu/pytorch-cifar>` has already included many classical
+neural network models. We use their implementation direclty for 
+
+- VGG
+
 .. automodule:: mlbench_core.models.pytorch
 .. currentmodule:: mlbench_core.models.pytorch
 

--- a/mlbench_core/api.py
+++ b/mlbench_core/api.py
@@ -1,11 +1,11 @@
 """ MLBench Master/Dashboard API Client Functionality """
 
-import requests
 import concurrent.futures
 import datetime
 import logging
+from kubernetes import client, config
+import requests
 
-from kubernetes import config, client
 
 OFFICIAL_IMAGES = {
     'Test Image': 'mlbench/mlbench_worker'
@@ -103,8 +103,8 @@ class ApiClient(object):
                 port = service.spec.ports[0].port
             elif service_type == "NodePort":
                 port = service.spec.ports[0].node_port
-                if (service.spec.external_i_ps
-                        and len(service.spec.external_i_ps) > 0):
+                if (service.spec.external_i_ps and
+                        len(service.spec.external_i_ps) > 0):
 
                     ip = service.spec.external_i_ps[0]
                 else:
@@ -269,7 +269,7 @@ class ApiClient(object):
                 "date": str(date),
                 "value": str(value),
                 "metadata": metadata
-             })
+            })
         return future
 
     def get_runs(self):
@@ -341,11 +341,11 @@ class ApiClient(object):
         """
         request_url = "{endpoint}runs/".format(endpoint=self.endpoint)
         data = {
-                "name": name,
-                "num_workers": num_workers,
-                "num_cpus": num_cpus,
-                "max_bandwidth": max_bandwidth
-             }
+            "name": name,
+            "num_workers": num_workers,
+            "num_cpus": num_cpus,
+            "max_bandwidth": max_bandwidth
+        }
 
         if custom_image_name is not None:
             data['image_name'] = 'custom_image'
@@ -361,7 +361,7 @@ class ApiClient(object):
             requests.post,
             request_url,
             data=data
-            )
+        )
         return future
 
     def get_worker_pods(self):

--- a/mlbench_core/controlflow/pytorch/checkpoints_evaluation.py
+++ b/mlbench_core/controlflow/pytorch/checkpoints_evaluation.py
@@ -1,10 +1,11 @@
 """Evaluate training/validation set using models in checkpoints"""
 import logging
-import torch
 
+from mlbench_core.utils.pytorch.distributed import AllReduceAggregation
 from mlbench_core.utils.pytorch.distributed import global_average
 from mlbench_core.utils.pytorch.helpers import iterate_dataloader
-from mlbench_core.utils.pytorch.distributed import AllReduceAggregation
+
+import torch
 
 logger = logging.getLogger('mlbench')
 

--- a/mlbench_core/controlflow/pytorch/checkpoints_evaluation.py
+++ b/mlbench_core/controlflow/pytorch/checkpoints_evaluation.py
@@ -1,0 +1,126 @@
+"""Evaluate training/validation set using models in checkpoints"""
+import logging
+import torch
+
+from mlbench_core.utils.pytorch.distributed import global_average
+from mlbench_core.utils.pytorch.helpers import iterate_dataloader
+from mlbench_core.utils.pytorch.distributed import AllReduceAggregation
+
+logger = logging.getLogger('mlbench')
+
+
+class CheckpointsEvaluationControlFlow(object):
+    """Evaluate models on training / validation dataset.
+
+    Args:
+        ckpt_dir (str): Path to checkpoints.
+        rank (int): The rank of the current process
+        world_size (int): The total number of workers
+        checkpointer (:obj:`Checkpointer`): Used to load checkpoints.
+        model (:obj:`torch.optim.Optimizer`): An optimizer for the given model.
+        epochs (int): Number of epochs to traing.
+        loss_function (:obj:`torch.nn.modules.loss._Loss`): loss function.
+        metrics (:obj:`list` of :obj:`mlbench_core.evaluation.pytorch.*`): metrics like TopKAccuracy.
+        use_cuda (bool): Whether to train on GPU or not. Default: `False`
+        dtype (str): The datatype to use for the dataloader data
+        max_batch_per_epoch (int): Maximum number of batches per epoch. Whole dataset
+        is used if not specified. Default: `None`
+    """
+
+    def __init__(self,
+                 ckpt_dir,
+                 rank,
+                 world_size,
+                 checkpointer,
+                 model,
+                 epochs,
+                 loss_function,
+                 metrics,
+                 use_cuda=False,
+                 dtype=None,
+                 max_batch_per_epoch=None):
+        self.ckpt_dir = ckpt_dir
+        self.rank = rank
+        self.checkpointer = checkpointer
+        self.model = model
+        self.epochs = epochs
+        self.loss_function = loss_function
+        self.metrics = metrics
+        self.dtype = dtype
+        self.max_batch_per_epoch = max_batch_per_epoch
+        self.use_cuda = use_cuda
+
+        self.model_agg_fn = AllReduceAggregation(
+            world_size=world_size).agg_model
+
+        self._check_checkpoints()
+
+    def _check_checkpoints(self):
+        for epoch in range(self.epochs):
+            self.checkpointer.checkpoint_exists(
+                self.ckpt_dir, self.rank, epoch)
+
+    def _load_model(self, epoch):
+        # Load epoch-rank model
+        model = self.checkpointer.load_model_by_epoch(
+            self.ckpt_dir, self.rank, epoch, self.model)
+
+        # aggregate models
+        self.model_agg_fn(model, op='avg')
+        return model
+
+    def evaluate_by_epochs(self, dataloader):
+        """Evaluate dataset using the averaged models.
+
+        In each epoch each process loads models and averages them. The averaged model is
+        used to evaluate train / validation dataset.
+
+        Args:
+            dataloader (:obj:`torch.utils.data.DataLoader`): The dataset to be evaluated.
+
+        Returns:
+            list: list of stats of models in each epoch.
+        """
+        stats_list = []
+        for epoch in range(self.epochs):
+            # Same model for all workers.
+            model = self._load_model(epoch)
+            model.eval()
+
+            stats = {"epoch": epoch, "count": 0, "total_loss": 0}
+            for metric in self.metrics:
+                stats['total_' + metric.name] = 0
+
+            data_iter = iterate_dataloader(
+                dataloader,
+                self.dtype,
+                self.max_batch_per_epoch,
+                self.use_cuda)
+
+            with torch.no_grad():
+                for i, (data, target) in enumerate(data_iter):
+                    output = model(data)
+
+                    # Compute loss and metrics.
+                    count = len(target)
+                    stats["count"] += count
+                    stats['total_loss'] += self.loss_function(
+                        output, target) * count
+                    for metric in self.metrics:
+                        stats['total_' +
+                              metric.name] += metric(output, target) * count
+
+                    logger.info("E{:4}B{:4}: total loss={:10.3e}"
+                                .format(epoch, i, stats['total_loss'] / stats['count']))
+
+            # Keep globally averaged loss / metrics, etc.
+            stats["loss"] = global_average(
+                stats["total_loss"], stats["count"]).item()
+            for metric in self.metrics:
+                stats[metric.name] = global_average(
+                    stats['total_' + metric.name], stats['count']).item()
+                del stats['total_' + metric.name]
+            del stats['count'], stats['total_loss']
+
+            stats_list.append(stats)
+        return stats_list

--- a/mlbench_core/controlflow/pytorch/controlflow.py
+++ b/mlbench_core/controlflow/pytorch/controlflow.py
@@ -149,8 +149,9 @@ class TrainValidation(object):
             # FIXME: The Timeit object can be a problem.
             self.train_epoch(dataloader_train)
 
-            is_best = self.do_validate(
-                dataloader_val) if self.perform_validation else False
+            is_best = False
+            if self.perform_validation:
+                is_best = self.do_validate(dataloader_val)
 
             if self.checkpoint:
                 self.checkpoint.save(self.tracker, self.model,

--- a/mlbench_core/controlflow/pytorch/controlflow.py
+++ b/mlbench_core/controlflow/pytorch/controlflow.py
@@ -252,7 +252,7 @@ class TrainValidation(object):
             str_builder.append("{} {:.2e}".format(
                 metric.name, self.tracker.epoch_stats[metric.name].avg))
 
-            log_metrics(
+            LogMetrics.log(
                 self.run_id,
                 self.rank,
                 self.tracker.current_epoch,

--- a/mlbench_core/controlflow/tensorflow/train_validation.py
+++ b/mlbench_core/controlflow/tensorflow/train_validation.py
@@ -1,9 +1,7 @@
 r"""A controlflow which train and evaluate a model."""
 import logging
-import tensorflow as tf
 from collections import defaultdict
-
-from mlbench_core.utils import Tracker, AverageMeter
+from mlbench_core.utils import AverageMeter, Tracker
 
 
 class TrainValidation(object):

--- a/mlbench_core/controlflow/tensorflow/train_validation.py
+++ b/mlbench_core/controlflow/tensorflow/train_validation.py
@@ -9,17 +9,33 @@ from mlbench_core.utils import Tracker, AverageMeter
 class TrainValidation(object):
     """A control flow to train and evaluate a model."""
 
-    def __init__(self, train_op, sess, loss, metrics,
-                 lr_scheduler_level, max_train_steps, train_epochs,
-                 batch_size, num_batches_per_epoch_for_train, num_batches_per_epoch_for_validation,
-                 train_set_init_op, validation_set_init_op):
+    def __init__(self,
+                 train_op,
+                 sess,
+                 loss,
+                 metrics,
+                 max_train_steps,
+                 train_epochs,
+                 batch_size,
+                 num_batches_per_epoch_for_train,
+                 num_batches_per_epoch_for_validation,
+                 train_set_init_op,
+                 validation_set_init_op,
+                 lr_scheduler_level='epoch'):
         """
         Args:
             train_op (:obj:`tf.Operation`): An operation for training models.
             sess (:obj:`tf.Session`): A session which the control flow will communicate.
-            is_training (bool or :obj:`tf.Tensor`): training the model with the number of atrs
             loss (:obj:`tf.Tensor`): The loss tensor.
             metrics (list of :obj:`tf.Tensor`): A list of metrics tensors.
+            max_train_steps (int): Number of steps for training (independent of lr)
+            train_epochs (int): Number of steps for training (may related to lr).
+            batch_size (int): Size of a batch.
+            num_batches_per_epoch_for_train (int): Number of batches in one training epoch
+            num_batches_per_epoch_for_validation (int): Number of batches in one validation epoch
+            train_set_init_op (:obj:`tf.Operation`): Op for initializing training dataset.
+            validation_set_init_op (:obj:`tf.Operation`): Op for initializing validation dataset.
+            lr_scheduler_level (str): Learning rate is updated based on `epoch` or `batch`.
         """
         self.batch_size = batch_size
         self.num_batches_per_epoch_for_train = num_batches_per_epoch_for_train

--- a/mlbench_core/dataset/imagerecognition/pytorch/dataloader.py
+++ b/mlbench_core/dataset/imagerecognition/pytorch/dataloader.py
@@ -1,7 +1,6 @@
 r""" Create dataset and dataloader in PyTorch. """
-import os
 import logging
-import math
+import os
 import torchvision.datasets as datasets
 import torchvision.transforms as transforms
 

--- a/mlbench_core/dataset/imagerecognition/tensorflow/cifar10.py
+++ b/mlbench_core/dataset/imagerecognition/tensorflow/cifar10.py
@@ -2,13 +2,12 @@ r"""Test the tensorflow load and preprocess cifar-10 correctly.
 
 Credit https://github.com/tensorflow/models/blob/master/tutorials/image/cifar10/cifar10_input.py
 """
-import types
+import logging
 import os
 import sys
 import tarfile
-import logging
+from six.moves import urllib, xrange
 import tensorflow as tf
-from six.moves import xrange, urllib
 
 
 class DatasetCifar(object):

--- a/mlbench_core/evaluation/pytorch/__init__.py
+++ b/mlbench_core/evaluation/pytorch/__init__.py
@@ -1,1 +1,3 @@
 from . import criterion, metrics
+
+__all__ = [criterion, metrics]

--- a/mlbench_core/evaluation/pytorch/metrics.py
+++ b/mlbench_core/evaluation/pytorch/metrics.py
@@ -62,5 +62,4 @@ class TopKAccuracy(object):
     @property
     def name(self):
         """str: Name of this metric."""
-        r"""Name of the metric."""
         return "Prec@{}".format(self.topk)

--- a/mlbench_core/evaluation/pytorch/metrics.py
+++ b/mlbench_core/evaluation/pytorch/metrics.py
@@ -1,7 +1,7 @@
 """Utilities for measuring the performance of a model."""
 
-from mlbench_core.utils.pytorch.distributed import global_average
 from mlbench_core.utils import AverageMeter
+from mlbench_core.utils.pytorch.distributed import global_average
 
 
 class TopKAccuracy(object):

--- a/mlbench_core/evaluation/tensorflow/__init__.py
+++ b/mlbench_core/evaluation/tensorflow/__init__.py
@@ -1,1 +1,3 @@
 from . import criterion
+
+__all__ = [criterion]

--- a/mlbench_core/lr_scheduler/pytorch/lr.py
+++ b/mlbench_core/lr_scheduler/pytorch/lr.py
@@ -121,7 +121,8 @@ def multistep_learning_rates_with_warmup(optimizer, world_size, lr, gamma, miles
         A learning rate scheduler (:obj:`torch.optim.lr_scheduler.LambdaLR`)
     """
     if bool(warmup_duration) != bool(warmup_lr):
-        raise ValueError("Either both or none of warmup_duration and warmup_lr have to be set")
+        raise ValueError(
+            "Either both or none of warmup_duration and warmup_lr have to be set")
 
     scaling_factor = 1
 
@@ -145,7 +146,8 @@ def multistep_learning_rates_with_warmup(optimizer, world_size, lr, gamma, miles
     def f(duration):
         if warmup_lr and duration <= warmup_duration:
             warmup_progress = duration / warmup_duration
-            lr = warmup_progress * base_lr + (1 - warmup_progress) * warmup_init_lr
+            lr = warmup_progress * base_lr + \
+                (1 - warmup_progress) * warmup_init_lr
         else:
             lr = base_lr * gamma ** bisect_right(milestones, duration)
         return lr / base_lr

--- a/mlbench_core/lr_scheduler/pytorch/lr.py
+++ b/mlbench_core/lr_scheduler/pytorch/lr.py
@@ -141,7 +141,7 @@ def multistep_learning_rates_with_warmup(optimizer,
     if warmup_lr:
         warmup_init_lr = warmup_lr
 
-    if not list(milestones) == sorted(milestones):
+    if list(milestones) != sorted(milestones):
         raise ValueError('Milestones should be a list of increasing integers.'
                          'Got {}'.format(milestones))
 
@@ -174,7 +174,7 @@ class MultistepLearningRatesWithWarmup(LambdaLR):
                  warmup_duration,
                  warmup_linear_scaling=True,
                  warmup_init_lr=None):
-        if not list(milestones) == sorted(milestones):
+        if list(milestones) != sorted(milestones):
             raise ValueError('Milestones should be a list of increasing integers.'
                              'Got {}'.format(milestones))
 

--- a/mlbench_core/lr_scheduler/pytorch/lr.py
+++ b/mlbench_core/lr_scheduler/pytorch/lr.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import argparse
+from bisect import bisect_right
 import numpy as np
-import re
-from torch.optim.lr_scheduler import LambdaLR, MultiStepLR
-from bisect import bisect_left, bisect_right
+from torch.optim.lr_scheduler import LambdaLR
 
 
 def const(optimizer):
@@ -66,7 +64,8 @@ def cyclical_learning_rates(optimizer, mode, gamma, cycle_length, base_lr, max_l
     Since :cite:`smith2017cyclical` mentioned that triangular, Welch, Hann windows produce equivalent results,
     we only implement triangular learning rate policy, also known as **linear cycle**.
 
-    The original implementation of :cite:`smith2017cyclical` can be found from `here <https://github.com/bckenstler/CLR>`_.
+    The original implementation of :cite:`smith2017cyclical` can be found from
+    `here <https://github.com/bckenstler/CLR>`_.
 
     :cite:`smith2017super` uses one cycle with extra epochs.
 
@@ -97,7 +96,14 @@ def cyclical_learning_rates(optimizer, mode, gamma, cycle_length, base_lr, max_l
                                      mode=mode)
 
 
-def multistep_learning_rates_with_warmup(optimizer, world_size, lr, gamma, milestones, warmup_duration=None, warmup_lr=None, warmup_linear_scaling=False):
+def multistep_learning_rates_with_warmup(optimizer,
+                                         world_size,
+                                         lr,
+                                         gamma,
+                                         milestones,
+                                         warmup_duration=None,
+                                         warmup_lr=None,
+                                         warmup_linear_scaling=False):
     """ Multistep Learning Rate Schedule with warmup
 
     In :cite:`goyal2017accurate`, warmup is used in order to apply the ``Linear Scaling Rule``.

--- a/mlbench_core/models/pytorch/resnet.py
+++ b/mlbench_core/models/pytorch/resnet.py
@@ -36,7 +36,7 @@ def batch_norm(num_features):
     """Create a batch normalization layer.
 
     See the Disclaimers in Kaiming's
-    `here <https://github.com/KaimingHe/deep-residual-networks/tree/a7026cb6d478e131b765b898c312e25f9f6dc031>`_
+    `repository <https://github.com/KaimingHe/deep-residual-networks/tree/a7026cb6d478e131b765b898c312e25f9f6dc031>`_.
 
     * compute the mean and variance on a sufficiently large traing batch instead of moving average;
     * learn gamma and beta in affine function.

--- a/mlbench_core/models/pytorch/resnet.py
+++ b/mlbench_core/models/pytorch/resnet.py
@@ -22,12 +22,12 @@ for image net. Here we only implemented the remaining models
 for CIFAR-10 dataset. Besides, their implementation uses projection shortcut by default.
 
 """
+from mlbench_core.utils.pytorch.helpers import convert_dtype
 
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
 
-from mlbench_core.utils.pytorch.helpers import convert_dtype
 
 _DEFAULT_RESNETCIFAR_VERSION = 1
 
@@ -36,7 +36,7 @@ def batch_norm(num_features):
     """Create a batch normalization layer.
 
     See the Disclaimers in Kaiming's
-    `github repository <https://github.com/KaimingHe/deep-residual-networks/tree/a7026cb6d478e131b765b898c312e25f9f6dc031>`_
+    `here <https://github.com/KaimingHe/deep-residual-networks/tree/a7026cb6d478e131b765b898c312e25f9f6dc031>`_
 
     * compute the mean and variance on a sufficiently large traing batch instead of moving average;
     * learn gamma and beta in affine function.
@@ -289,7 +289,7 @@ class PreActBlock(nn.Module):
         return out + shortcut
 
 
-class ResNet18_CIFAR10(nn.Module):
+class ResNet18CIFAR10(nn.Module):
     """ResNet implementation for CIFAR-10
 
     The ResNet structure defined in :cite:`he2016deep` and :cite:`he2016identity`.
@@ -303,7 +303,7 @@ class ResNet18_CIFAR10(nn.Module):
     """
 
     def __init__(self, layers, num_classes=1000):
-        super(ResNet18_CIFAR10, self).__init__()
+        super(ResNet18CIFAR10, self).__init__()
         self.prep = nn.Sequential(
             nn.Conv2d(3, 64, kernel_size=3, stride=1, padding=1, bias=False),
             nn.BatchNorm2d(64),
@@ -359,7 +359,7 @@ def resnet18_bkj(num_classes):
     Args:
         num_classes (int): The number of output classes.
     """
-    model = ResNet18_CIFAR10([2, 2, 2, 2], num_classes=num_classes)
+    model = ResNet18CIFAR10([2, 2, 2, 2], num_classes=num_classes)
     return model
 
 

--- a/mlbench_core/models/pytorch/vgg.py
+++ b/mlbench_core/models/pytorch/vgg.py
@@ -1,0 +1,47 @@
+'''VGG11/13/16/19 in Pytorch.
+
+From https://github.com/kuangliu/pytorch-cifar.'''
+import torch
+import torch.nn as nn
+
+
+cfg = {
+    'VGG11': [64, 'M', 128, 'M', 256, 256, 'M', 512, 512, 'M', 512, 512, 'M'],
+    'VGG13': [64, 64, 'M', 128, 128, 'M', 256, 256, 'M', 512, 512, 'M', 512, 512, 'M'],
+    'VGG16': [64, 64, 'M', 128, 128, 'M', 256, 256, 256, 'M', 512, 512, 512, 'M', 512, 512, 512, 'M'],
+    'VGG19': [64, 64, 'M', 128, 128, 'M', 256, 256, 256, 256, 'M', 512, 512, 512, 512, 'M', 512, 512, 512, 512, 'M'],
+}
+
+
+class VGG(nn.Module):
+    def __init__(self, vgg_name):
+        super(VGG, self).__init__()
+        self.features = self._make_layers(cfg[vgg_name])
+        self.classifier = nn.Linear(512, 10)
+
+    def forward(self, x):
+        out = self.features(x)
+        out = out.view(out.size(0), -1)
+        out = self.classifier(out)
+        return out
+
+    def _make_layers(self, cfg):
+        layers = []
+        in_channels = 3
+        for x in cfg:
+            if x == 'M':
+                layers += [nn.MaxPool2d(kernel_size=2, stride=2)]
+            else:
+                layers += [nn.Conv2d(in_channels, x, kernel_size=3, padding=1),
+                           nn.BatchNorm2d(x),
+                           nn.ReLU(inplace=True)]
+                in_channels = x
+        layers += [nn.AvgPool2d(kernel_size=1, stride=1)]
+        return nn.Sequential(*layers)
+
+
+def test():
+    net = VGG('VGG11')
+    x = torch.randn(2, 3, 32, 32)
+    y = net(x)
+    print(y.size())

--- a/mlbench_core/optim/pytorch/optim.py
+++ b/mlbench_core/optim/pytorch/optim.py
@@ -1,0 +1,164 @@
+import numpy as np
+import torch
+import torch.optim as optim
+from torch.optim.optimizer import Optimizer, required
+
+
+class sparsified_SGD(Optimizer):
+    r"""Implements sparsified version of stochastic gradient descent.
+
+    Args:
+        params (iterable): iterable of parameters to optimize or dicts defining
+            parameter groups
+        lr (float): learning rate
+        weight_decay (float, optional): weight decay (L2 penalty) (default: 0)
+        sparse_grad_size (int): Size of the sparsified gradients vector.
+
+    """
+
+    def __init__(self, params, lr=required, weight_decay=0, sparse_grad_size=10):
+
+        if lr is not required and lr < 0.0:
+            raise ValueError("Invalid learning rate: {}".format(lr))
+
+        if weight_decay < 0.0:
+            raise ValueError(
+                "Invalid weight_decay value: {}".format(weight_decay))
+
+        defaults = dict(lr=lr, weight_decay=weight_decay)
+
+        super(sparsified_SGD, self).__init__(params, defaults)
+
+        self.__create_gradients_memory()
+        self.__create_weighted_average_params()
+
+        self.num_coordinates = sparse_grad_size
+
+    def __setstate__(self, state):
+        super(sparsified_SGD, self).__setstate__(state)
+
+    def __create_weighted_average_params(self):
+        """ Create a memory to keep the weighted average of parameters in each iteration """
+        for group in self.param_groups:
+            for p in group['params']:
+                param_state = self.state[p]
+                param_state['estimated_w'] = torch.zeros_like(p.data)
+                p.data.normal_(0, 0.01)
+                param_state['estimated_w'].copy_(p.data)
+
+    def __create_gradients_memory(self):
+        """ Create a memory to keep gradients that are not used in each iteration """
+        for group in self.param_groups:
+            for p in group['params']:
+                param_state = self.state[p]
+                param_state['memory'] = torch.zeros_like(p.data)
+
+    def step(self, closure=None):
+        """Performs a single optimization step.
+
+        Arguments:
+            closure (callable, optional): A closure that reevaluates the model
+                and returns the loss.
+        """
+        loss = None
+        if closure is not None:
+            loss = closure()
+
+        for group in self.param_groups:
+
+            weight_decay = group['weight_decay']
+
+            for p in group['params']:
+
+                if p.grad is None:
+                    continue
+                d_p = p.grad.data
+
+                if weight_decay != 0:
+                    d_p.add_(weight_decay, p.data)
+                p.data.add_(-d_p)
+
+        return loss
+
+    def sparsify_gradients(self, model, lr, random_sparse):
+        """ Calls one of the sparsification functions (random or blockwise)"""
+        if random_sparse:
+            return self._random_sparsify(model, lr)
+        else:
+            return self._block_sparsify(model, lr)
+
+    def _random_sparsify(self, model, lr):
+        """
+        Sparsify the gradients vector by selecting 'k' of them randomly.
+        param model: learning model
+        param lr: learning rate
+        return: sparsified gradients vector ('k' gradients and their indices)
+        """
+        params_sparse_tensors = []
+
+        for ind, param in enumerate(model.parameters()):
+            self.state[param]['memory'] += param.grad.data * lr[0]
+
+            indices = np.random.choice(
+                param.data.size()[1], self.num_coordinates, replace=False)
+            sparse_tensor = torch.zeros(2, self.num_coordinates)
+
+            for i, random_index in enumerate(indices):
+                sparse_tensor[1,
+                              i] = self.state[param]['memory'][0, random_index]
+                self.state[param]['memory'][0, random_index] = 0
+            sparse_tensor[0, :] = torch.tensor(indices)
+
+            params_sparse_tensors.append(sparse_tensor)
+
+        return params_sparse_tensors
+
+    def _block_sparsify(self, model, lr):
+        """
+        Sparsify the gradients vector by selecting a block of them.
+        param model: learning model
+        param lr: learning rate
+        return: sparsified gradients vector
+        """
+        params_sparse_tensors = []
+
+        for param in model.parameters():
+            self.state[param]['memory'] += param.grad.data * lr[0]
+
+            num_block = int(param.data.size()[1] / self.num_coordinates)
+
+            self.current_block = np.random.randint(0, num_block)
+            begin_index = self.current_block * self.num_coordinates
+
+            if self.current_block == (num_block - 1):
+                end_index = param.data.size()[1] - 1
+            else:
+                end_index = begin_index + self.num_coordinates - 1
+            output_size = 1 + end_index - begin_index + 1
+
+            sparse_tensor = torch.zeros(1, output_size)
+            sparse_tensor[0, 0] = begin_index
+            sparse_tensor[0, 1:] = self.state[param]['memory'][0,
+                                                               begin_index: end_index + 1]
+            self.state[param]['memory'][0, begin_index: end_index + 1] = 0
+
+            self.current_block += 1
+            params_sparse_tensors.append(sparse_tensor)
+        return params_sparse_tensors
+
+    def update_estimated_weights(self, model, iteration, sparse_vector_size):
+        """ Updates the estimated parameters """
+        t = iteration
+        for ind, param in enumerate(model.parameters()):
+            tau = param.data.size()[1] / sparse_vector_size
+            rho = 6 * ((t + tau) ** 2) / ((1 + t) *
+                                          (6 * (tau ** 2) + t + 6 * tau * t + 2 * (t ** 2)))
+            self.state[param]['estimated_w'] = self.state[param]['estimated_w'] * \
+                (1 - rho) + param.data * rho
+
+    def get_estimated_weights(self, model):
+        """ Returns the weighted average parameter tensor """
+        estimated_params = []
+        for param in model.parameters():
+            estimated_params.append(self.state[param]['estimated_w'])
+        return estimated_params

--- a/mlbench_core/optim/pytorch/optim.py
+++ b/mlbench_core/optim/pytorch/optim.py
@@ -4,7 +4,7 @@ import torch.optim as optim
 from torch.optim.optimizer import Optimizer, required
 
 
-class sparsified_SGD(Optimizer):
+class SparsifiedSGD(Optimizer):
     r"""Implements sparsified version of stochastic gradient descent.
 
     Args:
@@ -27,7 +27,7 @@ class sparsified_SGD(Optimizer):
 
         defaults = dict(lr=lr, weight_decay=weight_decay)
 
-        super(sparsified_SGD, self).__init__(params, defaults)
+        super(SparsifiedSGD, self).__init__(params, defaults)
 
         self.__create_gradients_memory()
         self.__create_weighted_average_params()
@@ -35,7 +35,7 @@ class sparsified_SGD(Optimizer):
         self.num_coordinates = sparse_grad_size
 
     def __setstate__(self, state):
-        super(sparsified_SGD, self).__setstate__(state)
+        super(SparsifiedSGD, self).__setstate__(state)
 
     def __create_weighted_average_params(self):
         """ Create a memory to keep the weighted average of parameters in each iteration """

--- a/mlbench_core/optim/pytorch/optim.py
+++ b/mlbench_core/optim/pytorch/optim.py
@@ -1,6 +1,5 @@
 import numpy as np
 import torch
-import torch.optim as optim
 from torch.optim.optimizer import Optimizer, required
 
 

--- a/mlbench_core/utils/pytorch/__init__.py
+++ b/mlbench_core/utils/pytorch/__init__.py
@@ -11,7 +11,7 @@ __all__ = ['initialize_backends', 'Timeit', 'FCGraph']
 def initialize_backends(comm_backend='mpi', logging_level='INFO',
                         logging_file='/mlbench.log', use_cuda=False,
                         seed=None, cudnn_deterministic=False,
-                        ckpt_run_dir='/checkpoints', resume=False):
+                        ckpt_run_dir='/checkpoints', delete_existing_ckpts=False):
     """Initializes the backends.
 
     Sets up logging, sets up pytorch and configures paths
@@ -32,6 +32,6 @@ def initialize_backends(comm_backend='mpi', logging_level='INFO',
     rank, world_size, graph = config_pytorch(use_cuda, seed,
                                              cudnn_deterministic)
 
-    config_path(ckpt_run_dir, resume)
+    config_path(ckpt_run_dir, delete_existing_ckpts)
 
     return rank, world_size, graph

--- a/mlbench_core/utils/pytorch/checkpoint.py
+++ b/mlbench_core/utils/pytorch/checkpoint.py
@@ -30,18 +30,6 @@ class Checkpointer(object):
         self.save_stats = save_stats
         # self.runtime = {'cumu_time_val': []}
 
-    # def get_ckpt_id(self, epoch):
-    #     """ Get the name of a checkpoint
-
-    #     Args:
-    #         epoch (int): The current epoch.
-
-    #     Returns:
-    #         The name for the current checkpoint
-    #     """
-    #     # {epoch}_{batch} can be sorted
-    #     return "{epoch}_{rank}.pth.tar".format(epoch=epoch, rank=self.rank)
-
     def save(self, tracker, model, optimizer, scheduler, epoch, is_best):
         """ Saves a checkpoint
 
@@ -74,9 +62,7 @@ class Checkpointer(object):
                 shutil.copyfile(checkpoint_path, best_model_path)
         elif self.freq == CheckpointFreq.BEST:
             torch.save(state, best_model_path, pickle_module=dill)
-        elif self.freq == CheckpointFreq.NONE:
-            pass
-        else:
+        elif self.freq != CheckpointFreq.NONE:
             raise NotImplementedError
 
         self._maybe_save_stats(
@@ -192,13 +178,3 @@ def determine_restore_ckpt_path(rank, checkpoint_root):
 
     path = os.path.join(checkpoint_root, latest[0])
     return path
-
-
-# def maybe_resume(config, model, optimizer, scheduler):
-#     """Recover the state of config, model, optimizer and scheduler."""
-#     if 'resume' in config and config['resume']:
-#         # reload model from the latest checkpoint.
-#         config['runtime'] = resume(config, model, optimizer, scheduler)
-#     else:
-#         config['runtime'] = {}
-#     return config

--- a/mlbench_core/utils/pytorch/checkpoint.py
+++ b/mlbench_core/utils/pytorch/checkpoint.py
@@ -14,6 +14,7 @@ class Checkpointer(object):
         checkpoint_all (bool): Whether to checkpoint on all epochs
             or just when a new best score was achieved. Default: `False`
     """
+
     def __init__(self, ckpt_run_dir, rank, checkpoint_all=False):
         self.dirname = ckpt_run_dir
         self.rank = rank
@@ -98,6 +99,49 @@ class Checkpointer(object):
         checkpointer.runtime['cumu_time_val'] = checkpoint['tracker']['cumu_time_val']
 
         return checkpointer, model, optimizer, scheduler
+
+    @staticmethod
+    def load_model_by_epoch(ckpt_run_dir, rank, epoch, model):
+        """ Loads a checkpoint
+
+        Args:
+            ckpt_run_dir (str): Folder path of checkpoint directory
+            rank (int): The rank of the current worker
+            epoch (int): Epoch of the model to be loaded.
+            model (:obj:`torch.nn.Module`): a pytorch model to be trained and validated.
+
+        Returns:
+            `model`
+        """
+        checkpoint_path = os.path.join(
+            ckpt_run_dir, '{}_{}.pth.tar'.format(epoch, rank))
+
+        if not os.path.isfile(checkpoint_path):
+            raise FileNotFoundError(
+                "No checkpoint found at '{}' for rank '{}'".format(ckpt_run_dir, rank))
+
+        checkpoint = torch.load(checkpoint_path)
+
+        model.load_state_dict(checkpoint['model'])
+        return model
+
+    @staticmethod
+    def checkpoint_exists(ckpt_run_dir, rank, epoch):
+        """ Check if a checkpoint exists.
+
+        Args:
+            ckpt_run_dir (str): Folder path of checkpoint directory
+            rank (int): The rank of the current worker
+            epoch (int): Epoch of the model to be loaded.
+
+        Returns:
+            `model`
+        """
+        checkpoint_path = os.path.join(
+            ckpt_run_dir, '{}_{}.pth.tar'.format(epoch, rank))
+        if not os.path.isfile(checkpoint_path):
+            raise FileNotFoundError(
+                "No checkpoint found at '{}' for rank '{}'".format(ckpt_run_dir, rank))
 
 
 def determine_restore_ckpt_path(rank, checkpoint_root):

--- a/mlbench_core/utils/pytorch/distributed.py
+++ b/mlbench_core/utils/pytorch/distributed.py
@@ -31,6 +31,8 @@ def global_average(sum, count):
     return avg
 
 
+##########################################################################################
+
 class Aggregation(object):
     """Aggregate udpates / models from different processes."""
 
@@ -143,16 +145,6 @@ class SparsifiedAggregation(Aggregation):
     """Aggregate sparsified updates."""
 
     def __init__(self, model):
-        pass
-
-    def _agg(self, data, op):
-        pass
-
-
-class QuantizedAggregation(Aggregation):
-    """Aggregated quantized updates."""
-
-    def __init__(self):
         pass
 
     def _agg(self, data, op):

--- a/mlbench_core/utils/pytorch/distributed.py
+++ b/mlbench_core/utils/pytorch/distributed.py
@@ -142,7 +142,7 @@ class DecentralizedAggregation(Aggregation):
 class SparsifiedAggregation(Aggregation):
     """Aggregate sparsified updates."""
 
-    def __init__(self, model,):
+    def __init__(self, model):
         pass
 
     def _agg(self, data, op):

--- a/mlbench_core/utils/pytorch/distributed.py
+++ b/mlbench_core/utils/pytorch/distributed.py
@@ -29,3 +29,96 @@ def global_average(sum, count):
         return array[0] / array[1]
     avg = helper([sum, count])
     return avg
+
+
+class Aggregation(object):
+    """Aggregate udpates / models from different processes."""
+
+    def agg_grad(self, data, op):
+        """Aggregate data using `op` operation.
+
+        Args:
+            data (:obj:`torch.Tensor`): A Tensor to be aggragated.
+            op (str): Aggregation methods like `avg`, `sum`, `min`, `max`, etc.
+        """
+        raise NotImplementedError
+
+    def agg_model(self, model, op):
+        """Aggregate models layer by layer.
+
+        Args:
+            model (:obj:`torch.Module`): Models to be averaged.
+            op (str): Aggregation methods like `avg`, `sum`, `min`, `max`, etc.
+        """
+        # Aggregate layer by layer
+        for _, param in enumerate(model.parameters()):
+            grad = self.agg_grad(param.grad.data, op=op)
+            param.grad.data = grad
+
+
+class AllReduceAggregation(Aggregation):
+    """Aggregate udpates / models from different processes."""
+
+    def __init__(self, world_size):
+        self.world_size = world_size
+
+    def agg_grad(self, data, op):
+        """Aggregate data using `op` operation.
+
+        Args:
+            data (:obj:`torch.Tensor`): A Tensor to be aggragated.
+            op (str): Aggregation methods like `avg`, `sum`, `min`, `max`, etc.
+
+        Returns:
+            :obj:`torch.Tensor`: An aggregated tensor.
+        """
+        if op == 'avg':
+            dist.all_reduce(data, op=dist.reduce_op.SUM)
+            data /= self.world_size
+        else:
+            raise NotImplementedError
+        return data
+
+
+class DecentralizedAggregation(Aggregation):
+    """Aggregate updates in a decentralized manner."""
+
+    def __init__(self, rank, neighbors):
+        """
+        Args:
+            rank (int): Rank of the current process
+            neighbors (list): A list of ranks of its neighbors.
+        """
+        assert rank not in neighbors
+        self.rank = rank
+        self.neighbors = neighbors
+
+    def agg_grad(self, data, op):
+        """Aggregate data using `op` operation.
+
+        Args:
+            data (:obj:`torch.Tensor`): A Tensor to be aggragated.
+            op (str): Aggregation methods like `avg`, `sum`, `min`, `max`, etc.
+
+        Returns:
+            :obj:`torch.Tensor`: An aggregated tensor.
+        """
+        # Create some tensors to host the values from neighborhood.
+        local_data = {i: torch.zeros_like(data) for i in self.neighbors}
+        local_data[self.rank] = data
+
+        reqs = []
+        for node in self.neighbors:
+            reqs.append(dist.isend(tensor=local_data[self.rank], dst=node))
+            reqs.append(dist.irecv(tensor=local_data[node], src=node))
+
+        for req in reqs:
+            req.wait()
+
+        # Aggregate local_data
+        if op == 'avg':
+            output = sum(local_data.values()) / (len(self.neighbors) + 1)
+        else:
+            raise NotImplementedError("op {} is not supported yet.".format(op))
+
+        return output

--- a/mlbench_core/utils/pytorch/helpers.py
+++ b/mlbench_core/utils/pytorch/helpers.py
@@ -1,19 +1,17 @@
 r"""Helper functions."""
 
-import time
 import datetime
 import itertools
-import shutil
-import os
 import logging
-import socket
+import os
 import random
+import shutil
+import socket
+import time
+from mlbench_core.api import ApiClient
+from mlbench_core.utils.pytorch.topology import FCGraph
 import torch
 import torch.distributed as dist
-
-from mlbench_core.utils.pytorch import checkpoint
-from mlbench_core.utils.pytorch.topology import FCGraph
-from mlbench_core.api import ApiClient
 
 
 class Timeit(object):

--- a/mlbench_core/utils/pytorch/helpers.py
+++ b/mlbench_core/utils/pytorch/helpers.py
@@ -71,10 +71,7 @@ def maybe_range(maximum):
 def update_best_runtime_metric(tracker, metric_value, metric_name):
     """Update the runtime information to config if the metric value is the best."""
     best_metric_name = "best_{}".format(metric_name)
-    if best_metric_name in tracker.records:
-        is_best = metric_value > tracker.best_metric_value
-    else:
-        is_best = True
+    is_best = metric_value > tracker.best_metric_value
 
     if is_best:
         tracker.best_metric_name = best_metric_name

--- a/mlbench_core/utils/pytorch/helpers.py
+++ b/mlbench_core/utils/pytorch/helpers.py
@@ -198,7 +198,7 @@ class LogMetrics(object):
     deprecated_in="1.1.1",
     details="This method has performance implications, use"
     " mlbench_core.utils.pytorch.helpers.LogMetrics instead")
-def log_metrics(run_id, rank, epoch, metric_name, value):
+def log_metrics(run_id, rank, epoch, metric_name, value, tracker=None, time=None):
     """ Log metrics to mlbench master/dashboard
 
     Args:

--- a/mlbench_core/utils/pytorch/helpers.py
+++ b/mlbench_core/utils/pytorch/helpers.py
@@ -195,14 +195,11 @@ def log_metrics(run_id, rank, epoch, metric_name, value):
             metric_name,
             value,
             metadata="{{rank: {}, epoch:{}}}".format(rank, epoch))
-    else:
-        pass
 
 
-def config_path(ckpt_run_dir, resume=False):
+def config_path(ckpt_run_dir, delete_existing_ckpts=False):
     """Config the path used during the experiments."""
-
-    if resume:
+    if delete_existing_ckpts:
         print("Remove previous checkpoint directory : {}".format(
             ckpt_run_dir))
         shutil.rmtree(ckpt_run_dir, ignore_errors=True)

--- a/mlbench_core/utils/pytorch/topology.py
+++ b/mlbench_core/utils/pytorch/topology.py
@@ -13,15 +13,16 @@ def _ranks_on_same_node(rank, world_size):
     encoding += [-1 for c in range(max_hostname_length - len(hostname))]
     encoding = torch.IntTensor(encoding)
 
-    all_encodings = [torch.IntTensor([0] * max_hostname_length) for _ in range(world_size)]
+    all_encodings = [torch.IntTensor([0] * max_hostname_length)
+                     for _ in range(world_size)]
     dist.all_gather(all_encodings, encoding)
 
     all_encodings = [ec.numpy().tolist() for ec in all_encodings]
-    counter = 0
-    for i in range(rank):
+    ranks = []
+    for i in range(world_size):
         if all_encodings[rank] == all_encodings[i]:
-            counter += 1
-    return counter
+            ranks.append(i)
+    return ranks
 
 
 class FCGraph(object):
@@ -47,7 +48,9 @@ class FCGraph(object):
 
     def assigned_gpu_id(self):
         num_gpus_on_device = torch.cuda.device_count()
-        assigned_id = _ranks_on_same_node(self.rank, self.world_size)
+        ranks = _ranks_on_same_node(self.rank, self.world_size)
+        # raise NotImplementedError(self.rank, ranks)
+        assigned_id = ranks.index(self.rank) % num_gpus_on_device
         torch.cuda.set_device(assigned_id)
 
     def __str__(self):

--- a/tests/test_controlflow_pytorch.py
+++ b/tests/test_controlflow_pytorch.py
@@ -67,11 +67,9 @@ def test_training(mocker, model, optimizer, loss_function, metrics, scheduler):
     mocker.patch('mlbench_core.controlflow.pytorch.controlflow.log_metrics')
 
     batch_size = 2
-    agg_fn = AllReduceAggregation(world_size=1).agg_model
 
     tv = TrainValidation(model, optimizer, loss_function,
-                         metrics, scheduler, batch_size, 10, 0, 1, 1, 'fp32',
-                         agg_fn=agg_fn)
+                         metrics, scheduler, batch_size, 10, 0, 1, 1, 'fp32')
 
     train_set = [random.random() for _ in range(100)]
     train_set = [
@@ -94,5 +92,5 @@ def test_training(mocker, model, optimizer, loss_function, metrics, scheduler):
         repartition_per_epoch=True)
 
     assert tv.tracker.current_epoch == 9
-    assert tv.tracker.records['best_epoch'] > -1
-    assert tv.tracker.records['best_Prec@1'] > 50.0
+    assert tv.tracker.best_epoch > -1
+    assert tv.tracker.best_metric_value > 50.0

--- a/tests/test_controlflow_pytorch.py
+++ b/tests/test_controlflow_pytorch.py
@@ -93,6 +93,6 @@ def test_training(mocker, model, optimizer, loss_function, metrics, scheduler):
         dataloader_val_fn=lambda: test_loader,
         repartition_per_epoch=True)
 
-    assert tv.tracker.current_epoch == 10
-    assert tv.tracker.records['best_epoch'] > 0
+    assert tv.tracker.current_epoch == 9
+    assert tv.tracker.records['best_epoch'] > -1
     assert tv.tracker.records['best_Prec@1'] > 50.0

--- a/tests/test_helpers_pytorch.py
+++ b/tests/test_helpers_pytorch.py
@@ -58,17 +58,20 @@ def test_update_best_runtime_metric(mocker):
     tracker.current_epoch = 1
     #tracker = mocker.patch('mlbench_core.utils.pytorch.helpers.Tracker')
 
-    is_best, best_metric_name = update_best_runtime_metric(tracker, 10.0, 'prec')
+    is_best, best_metric_name = update_best_runtime_metric(
+        tracker, 10.0, 'prec')
 
     assert is_best == True
     assert best_metric_name == "best_prec"
 
-    is_best, best_metric_name = update_best_runtime_metric(tracker, 11.0, 'prec')
+    is_best, best_metric_name = update_best_runtime_metric(
+        tracker, 11.0, 'prec')
 
     assert is_best == True
     assert best_metric_name == "best_prec"
 
-    is_best, best_metric_name = update_best_runtime_metric(tracker, 9.0, 'prec')
+    is_best, best_metric_name = update_best_runtime_metric(
+        tracker, 9.0, 'prec')
 
     assert is_best == False
     assert best_metric_name == "best_prec"
@@ -94,7 +97,8 @@ def test_config_pytorch(mocker):
     mocker.patch('torch.distributed.get_world_size', return_value=1)
     mocker.patch('mlbench_core.utils.pytorch.helpers.FCGraph')
 
-    rank, world_size, graph = config_pytorch(use_cuda=False, seed=42, cudnn_deterministic=True)
+    rank, world_size, graph = config_pytorch(
+        use_cuda=False, seed=42, cudnn_deterministic=True)
 
     assert rank == 1
     assert world_size == 1
@@ -115,12 +119,12 @@ def test_config_path(mocker):
     sh = mocker.patch('shutil.rmtree')
     osmk = mocker.patch('os.makedirs')
 
-    config_path('/tmp/checkpoints', resume=False)
+    config_path('/tmp/checkpoints', delete_existing_ckpts=False)
 
     osmk.assert_called_once_with('/tmp/checkpoints', exist_ok=True)
     assert sh.call_count == 0
 
-    config_path('/tmp/checkpoints', resume=True)
+    config_path('/tmp/checkpoints', delete_existing_ckpts=True)
 
     assert sh.call_count == 1
     assert osmk.call_count == 2
@@ -131,7 +135,8 @@ def test_iterate_dataloader(mocker):
         (torch.IntTensor([0]), torch.IntTensor([1])),
         (torch.IntTensor([2]), torch.IntTensor([3]))]
 
-    it = iterate_dataloader(dataloader, 'fp32', max_batch_per_epoch=2, transform_target_type=True)
+    it = iterate_dataloader(
+        dataloader, 'fp32', max_batch_per_epoch=2, transform_target_type=True)
 
     first = next(it)
 

--- a/tests/test_helpers_pytorch.py
+++ b/tests/test_helpers_pytorch.py
@@ -7,7 +7,6 @@ import pytest
 import time
 import itertools
 import torch
-import torch.distributed as dist
 
 from mlbench_core.utils.pytorch.helpers import *
 from mlbench_core.utils import Tracker
@@ -56,24 +55,25 @@ def test_update_best_runtime_metric(mocker):
     tracker = Tracker()
     tracker.records = {}
     tracker.current_epoch = 1
-    #tracker = mocker.patch('mlbench_core.utils.pytorch.helpers.Tracker')
+    tracker.best_metric_value = 0
+    # tracker = mocker.patch('mlbench_core.utils.pytorch.helpers.Tracker')
 
     is_best, best_metric_name = update_best_runtime_metric(
         tracker, 10.0, 'prec')
 
-    assert is_best == True
+    assert is_best
     assert best_metric_name == "best_prec"
 
     is_best, best_metric_name = update_best_runtime_metric(
         tracker, 11.0, 'prec')
 
-    assert is_best == True
+    assert is_best
     assert best_metric_name == "best_prec"
 
     is_best, best_metric_name = update_best_runtime_metric(
         tracker, 9.0, 'prec')
 
-    assert is_best == False
+    assert not is_best
     assert best_metric_name == "best_prec"
 
 


### PR DESCRIPTION
For the moment, we use something like the following snippet for communication and applying gradient.
```python
# loss.backward()
# Average the gradients from all of the nodes
global_average(param.grad.data, op=dist.op.SUM)
# Apply gradients to weights
optimizer.step()
```
But this is not flexible enough when we need to
- average with neighbors instead of all nodes;
- average the weight instead of gradient;
- communicate a sparsified / quantized vector instead of full vector;
- ...

In this PR, the control flow is changed to remove the explicit `global_average` and simply use the following snippet to update gradient
```python
# loss.backward()
# Apply gradients to weights
optimizer.step()
```
It is up to user to decide how to apply the gradients from all of the nodes. If the optimizer is native `optim.SGD`, then the `.step()` does not average the gradients. We can simply use a  wrapper or a subclass of `optim.SGD` and overwrite `.step()` to take care of communication.

Associated examples (decentralized, sign sgd, sparsified sgd etc) will be added to mlbench-benchmarks. 

Besides, a few changes have been made like
- Fix bugs in resuming training from checkpoint;
- Changes for flake8 linting information.