### PR TITLE
Remove dimension check in TopKAccuracy

### DIFF
--- a/mlbench_core/evaluation/pytorch/metrics.py
+++ b/mlbench_core/evaluation/pytorch/metrics.py
@@ -81,8 +81,6 @@ class TopKAccuracy(MLBenchMetric):
                 "Cannot compute top {} accuracy with "
                 "input dimension {}".format(self.topk, dim)
             )
-        if dim > 2:
-            raise ValueError("Cannot compute top 1 accuracy with more than 2 ")
         return output
 
     @property


### PR DESCRIPTION
The benchmark images are failing because of this check. @ehoelzl mentioned we should delete it because it is not needed anymore. 