### PR TITLE
Add NCCL & GLOO Backend support

### DIFF
--- a/mlbench_core/dataset/util/pytorch/partition.py
+++ b/mlbench_core/dataset/util/pytorch/partition.py
@@ -46,7 +46,7 @@ class Partitioner(object):
         # broadcast.
         indices = torch.IntTensor(indices)
 
-        dist.broadcast( get_backend_tensor(indices), src=0 )
+        dist.broadcast(get_backend_tensor(indices), src=0)
 
         return list(indices)
 

--- a/mlbench_core/dataset/util/pytorch/partition.py
+++ b/mlbench_core/dataset/util/pytorch/partition.py
@@ -43,6 +43,10 @@ class Partitioner(object):
 
         # broadcast.
         indices = torch.IntTensor(indices)
+        
+        if dist.get_backend() == dist.Backend.NCCL:
+            indices = indices.cuda()
+
         dist.broadcast(indices, src=0)
         return list(indices)
 

--- a/mlbench_core/dataset/util/pytorch/partition.py
+++ b/mlbench_core/dataset/util/pytorch/partition.py
@@ -7,6 +7,9 @@ import numpy as np
 import torch
 import torch.distributed as dist
 
+from mlbench_core.utils.pytorch.topology import get_backend_tensor
+
+
 _logger = logging.getLogger("mlbench")
 
 
@@ -43,14 +46,8 @@ class Partitioner(object):
 
         # broadcast.
         indices = torch.IntTensor(indices)
-        
-        if dist.get_backend() == dist.Backend.NCCL:
-            indices = indices.cuda()
 
-        dist.broadcast(indices, src=0)
-
-        if dist.get_backend() == dist.Backend.NCCL:
-            indices = indices.cpu()
+        dist.broadcast( get_backend_tensor(indices), src=0 )
 
         return list(indices)
 

--- a/mlbench_core/dataset/util/pytorch/partition.py
+++ b/mlbench_core/dataset/util/pytorch/partition.py
@@ -48,6 +48,10 @@ class Partitioner(object):
             indices = indices.cuda()
 
         dist.broadcast(indices, src=0)
+
+        if dist.get_backend() == dist.Backend.NCCL:
+            indices = indices.cpu()
+
         return list(indices)
 
 

--- a/mlbench_core/dataset/util/pytorch/partition.py
+++ b/mlbench_core/dataset/util/pytorch/partition.py
@@ -7,8 +7,7 @@ import numpy as np
 import torch
 import torch.distributed as dist
 
-from mlbench_core.utils.pytorch.topology import get_backend_tensor
-
+from mlbench_core.utils.pytorch.distributed import get_backend_tensor
 
 _logger = logging.getLogger("mlbench")
 

--- a/mlbench_core/optim/pytorch/optim.py
+++ b/mlbench_core/optim/pytorch/optim.py
@@ -413,7 +413,8 @@ class SignSGD(SGD):
                 p.data.add_(-group["lr"], torch.sign(d_p))
 
         return loss
-    
+
+
 class CentralizedAdam(Adam):
     r"""Implements centralized Adam algorithm.
 
@@ -437,10 +438,10 @@ class CentralizedAdam(Adam):
         self,
         world_size,
         model,
-        lr=1e-3, 
-        betas=(0.9, 0.999), 
+        lr=1e-3,
+        betas=(0.9, 0.999),
         eps=1e-8,
-        weight_decay=0, 
+        weight_decay=0,
         amsgrad=False,
         average_models=True,
     ):

--- a/mlbench_core/utils/pytorch/__init__.py
+++ b/mlbench_core/utils/pytorch/__init__.py
@@ -39,19 +39,21 @@ def initialize_backends(
     """
 
     if not (hasattr(dist, "_initialized") and dist._initialized):
-        
+
         if comm_backend in [dist.Backend.GLOO, dist.Backend.NCCL]:
 
             if comm_backend == dist.Backend.NCCL:
-                assert (torch.cuda.is_available(), 
-                        "Invalid use of NCCL backend without CUDA support available")
+                assert (
+                    torch.cuda.is_available(),
+                    "Invalid use of NCCL backend without CUDA support available",
+                )
 
-            hosts = hosts.split(',')
+            hosts = hosts.split(",")
             os.environ["MASTER_ADDR"] = hosts[0]
-            os.environ['MASTER_PORT'] = '29500'
+            os.environ["MASTER_PORT"] = "29500"
             os.environ["RANK"] = str(rank)
             os.environ["WORLD_SIZE"] = str(len(hosts))
-        
+
         dist.init_process_group(comm_backend)
 
     config_logging(logging_level, logging_file)

--- a/mlbench_core/utils/pytorch/__init__.py
+++ b/mlbench_core/utils/pytorch/__init__.py
@@ -44,9 +44,8 @@ def initialize_backends(
 
             if comm_backend == dist.Backend.NCCL:
                 assert (
-                    torch.cuda.is_available(),
-                    "Invalid use of NCCL backend without CUDA support available",
-                )
+                    torch.cuda.is_available()
+                ), "Invalid use of NCCL backend without CUDA support available"
 
             hosts = hosts.split(",")
             os.environ["MASTER_ADDR"] = hosts[0]

--- a/mlbench_core/utils/pytorch/__init__.py
+++ b/mlbench_core/utils/pytorch/__init__.py
@@ -7,12 +7,15 @@ from .topology import FCGraph
 
 from contextlib import contextmanager
 
+import os
 __all__ = ["initialize_backends", "Timeit", "FCGraph"]
 
 
 @contextmanager
 def initialize_backends(
     comm_backend="mpi",
+    hosts=None,
+    rank=-1,
     logging_level="INFO",
     logging_file="/mlbench.log",
     use_cuda=False,
@@ -34,6 +37,14 @@ def initialize_backends(
     """
 
     if not (hasattr(dist, "_initialized") and dist._initialized):
+        
+        if comm_backend != "mpi":
+            hosts = hosts.split(',')
+            os.environ["MASTER_ADDR"] = hosts[0]
+            os.environ['MASTER_PORT'] = '29500'
+            os.environ["RANK"] = str(rank)
+            os.environ["WORLD_SIZE"] = str(len(hosts))
+        
         dist.init_process_group(comm_backend)
 
     config_logging(logging_level, logging_file)

--- a/mlbench_core/utils/pytorch/__init__.py
+++ b/mlbench_core/utils/pytorch/__init__.py
@@ -8,6 +8,8 @@ from .topology import FCGraph
 from contextlib import contextmanager
 
 import os
+import torch
+
 __all__ = ["initialize_backends", "Timeit", "FCGraph"]
 
 
@@ -38,7 +40,12 @@ def initialize_backends(
 
     if not (hasattr(dist, "_initialized") and dist._initialized):
         
-        if comm_backend != "mpi":
+        if comm_backend in [dist.Backend.GLOO, dist.Backend.NCCL]:
+
+            if comm_backend == dist.Backend.NCCL:
+                assert (torch.cuda.is_available(), 
+                        "Invalid use of NCCL backend without CUDA support available")
+
             hosts = hosts.split(',')
             os.environ["MASTER_ADDR"] = hosts[0]
             os.environ['MASTER_PORT'] = '29500'

--- a/mlbench_core/utils/pytorch/distributed.py
+++ b/mlbench_core/utils/pytorch/distributed.py
@@ -1,6 +1,7 @@
 import torch
 import torch.distributed as dist
 
+from .topology import get_backend_tensor
 
 def broadcast(tensor, src):
     return dist.broadcast(tensor, src=src)
@@ -24,9 +25,8 @@ def aggregate_gradients(model, world_size, average_models=False):
 
 def global_average(sum, count):
     def helper(array):
-        array = torch.Tensor(array)
-        if dist.get_backend() == "nccl":
-            array = array.cuda()
+        array = get_backend_tensor( torch.Tensor(array) )
+        
         dist.all_reduce(array, op=dist.reduce_op.SUM)
         return array[0] / array[1]
 

--- a/mlbench_core/utils/pytorch/distributed.py
+++ b/mlbench_core/utils/pytorch/distributed.py
@@ -1,7 +1,5 @@
 import torch
 import torch.distributed as dist
-from torch import distributed as dist
-
 
 def broadcast(tensor, src):
     return dist.broadcast(tensor, src=src)

--- a/mlbench_core/utils/pytorch/distributed.py
+++ b/mlbench_core/utils/pytorch/distributed.py
@@ -25,6 +25,8 @@ def aggregate_gradients(model, world_size, average_models=False):
 def global_average(sum, count):
     def helper(array):
         array = torch.Tensor(array)
+        if dist.get_backend() == "nccl":
+            array = array.cuda()
         dist.all_reduce(array, op=dist.reduce_op.SUM)
         return array[0] / array[1]
 

--- a/mlbench_core/utils/pytorch/distributed.py
+++ b/mlbench_core/utils/pytorch/distributed.py
@@ -1,7 +1,7 @@
 import torch
 import torch.distributed as dist
+from torch import distributed as dist
 
-from .topology import get_backend_tensor
 
 def broadcast(tensor, src):
     return dist.broadcast(tensor, src=src)
@@ -153,3 +153,9 @@ class SparsifiedAggregation(Aggregation):
 
     def _agg(self, data, op):
         pass
+
+
+def get_backend_tensor(tensor):
+    if dist.is_initialized() and dist.get_backend() == dist.Backend.NCCL:
+        return tensor.cuda()
+    return tensor

--- a/mlbench_core/utils/pytorch/distributed.py
+++ b/mlbench_core/utils/pytorch/distributed.py
@@ -25,8 +25,8 @@ def aggregate_gradients(model, world_size, average_models=False):
 
 def global_average(sum, count):
     def helper(array):
-        array = get_backend_tensor( torch.Tensor(array) )
-        
+        array = get_backend_tensor(torch.Tensor(array))
+
         dist.all_reduce(array, op=dist.reduce_op.SUM)
         return array[0] / array[1]
 

--- a/mlbench_core/utils/pytorch/distributed.py
+++ b/mlbench_core/utils/pytorch/distributed.py
@@ -1,6 +1,7 @@
 import torch
 import torch.distributed as dist
 
+
 def broadcast(tensor, src):
     return dist.broadcast(tensor, src=src)
 

--- a/mlbench_core/utils/pytorch/helpers.py
+++ b/mlbench_core/utils/pytorch/helpers.py
@@ -293,5 +293,3 @@ def maybe_cuda(module, use_cuda):
     if use_cuda:
         module.cuda()
     return module
-
-

--- a/mlbench_core/utils/pytorch/helpers.py
+++ b/mlbench_core/utils/pytorch/helpers.py
@@ -8,12 +8,12 @@ import random
 import shutil
 import socket
 import time
+
+import deprecation
+import torch
 from mlbench_core.api import ApiClient
 from mlbench_core.utils.pytorch.topology import FCGraph
-
-import torch
-import torch.distributed as dist
-import deprecation
+from torch import distributed as dist
 
 
 class Timeit(object):
@@ -293,3 +293,5 @@ def maybe_cuda(module, use_cuda):
     if use_cuda:
         module.cuda()
     return module
+
+

--- a/mlbench_core/utils/pytorch/topology.py
+++ b/mlbench_core/utils/pytorch/topology.py
@@ -6,6 +6,9 @@ import torch.distributed as dist
 def _ranks_on_same_node(rank, world_size):
     hostname = socket.gethostname()
     hostname_length = torch.IntTensor([len(hostname)])
+    if dist.get_backend() == "nccl":
+        hostname_length = hostname_length.cuda()
+
     dist.all_reduce(hostname_length, op=dist.reduce_op.MAX)
     max_hostname_length = hostname_length.item()
 

--- a/mlbench_core/utils/pytorch/topology.py
+++ b/mlbench_core/utils/pytorch/topology.py
@@ -2,11 +2,7 @@ import socket
 import torch
 import torch.distributed as dist
 
-
-def get_backend_tensor(tensor):
-    if dist.get_backend() == "nccl":
-        return tensor.cuda()
-    return tensor
+from .helpers import get_backend_tensor
     
 
 def _ranks_on_same_node(rank, world_size):
@@ -26,10 +22,10 @@ def _ranks_on_same_node(rank, world_size):
     dist.all_gather(all_encodings, encoding)
 
 
-    if dist.get_backend() == "nccl":
-        all_encodings = [ec.cpu().numpy().tolist() for ec in all_encodings]
-    else:
-        all_encodings = [ec.numpy().tolist() for ec in all_encodings]
+    if dist.get_backend() == dist.Backend.NCCL:
+        all_encodings = [ec.cpu() for ec in all_encodings]
+    
+    all_encodings = [ec.numpy().tolist() for ec in all_encodings]
         
     ranks = []
     for i in range(world_size):

--- a/mlbench_core/utils/pytorch/topology.py
+++ b/mlbench_core/utils/pytorch/topology.py
@@ -16,16 +16,16 @@ def _ranks_on_same_node(rank, world_size):
     encoding = get_backend_tensor(torch.IntTensor(encoding))
 
     all_encodings = [
-        get_backend_tensor(torch.IntTensor([0] * max_hostname_length)) for _ in range(world_size)
+        get_backend_tensor(torch.IntTensor([0] * max_hostname_length))
+        for _ in range(world_size)
     ]
     dist.all_gather(all_encodings, encoding)
 
-
     if dist.get_backend() == dist.Backend.NCCL:
         all_encodings = [ec.cpu() for ec in all_encodings]
-    
+
     all_encodings = [ec.numpy().tolist() for ec in all_encodings]
-        
+
     ranks = []
     for i in range(world_size):
         if all_encodings[rank] == all_encodings[i]:

--- a/mlbench_core/utils/pytorch/topology.py
+++ b/mlbench_core/utils/pytorch/topology.py
@@ -2,8 +2,10 @@ import socket
 import torch
 import torch.distributed as dist
 
-from .helpers import get_backend_tensor
-    
+def get_backend_tensor(tensor):
+    if dist.get_backend() == dist.Backend.NCCL:
+        return tensor.cuda()
+    return tensor    
 
 def _ranks_on_same_node(rank, world_size):
     hostname = socket.gethostname()


### PR DESCRIPTION
These changes are for NCCL support, but they also allow to run Gloo, so this PR ties in with Martin's PR in `mlbench-benchmarks` (https://github.com/mlbench/mlbench-benchmarks/pull/31).

Things to note for NCCL and Gloo:
1. The checkbox saying "run on all nodes" should be ticked in the dashboard, otherwise the run will freeze.
2. The command line should not use `mpirun`, e.g. `/conda/bin/python /codes/main.py --run_id {run_id} --rank {rank} --hosts {hosts} --backend nccl`

Summary of changes:
- Added `hosts`, `rank` parameters to `initialize_backends` + environment variable initialization for NCCL and Gloo
- Added transformations to CUDA tensors in `{topology,distributed,partition}.py` when backend is NCCL