### PR TITLE
num_workers fix

### DIFF
--- a/mlbench_core/cli/cli.py
+++ b/mlbench_core/cli/cli.py
@@ -383,6 +383,8 @@ def create_gcloud(
             "your credentials."
         )
 
+    assert num_workers >= 2, "Number of workers should be at least 2"
+
     if not project:
         project = default_project
 


### PR DESCRIPTION
Fix for #38, I just added an assert statement in create_gcloud.
When we add support for other distributed environments (AWS, DIND) in the CLI, these kinds of checks should be factored out to a higher-level function.