### PR TITLE
Fix ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,37 @@
-# Config file for automatic testing at travis-ci.org
-jobs:
+dist: xenial
+
+
+language: python
+
+matrix:
   include:
-    - stage: test
-      language: python
-      python:
-        - 3.6
-        - 3.7
-
-      # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-      install:
-        - pip install --progress-bar off -U tox-travis
-
-      # Command to run tests, e.g. python setup.py test
-      script:
-        - tox
+    - python: 3.6
+      env: TOXENV=black
+  
+install:
+  - pip install tox
 
 
-stages:
-  - test
+script:
+  - tox
+  -
+## Config file for automatic testing at travis-ci.org
+#jobs:
+#  include:
+#    - stage: test
+#      language: python
+#      python:
+#        - 3.6
+#        - 3.7
+#
+#      # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
+#      install:
+#        - pip install --progress-bar off -U tox-travis
+#
+#      # Command to run tests, e.g. python setup.py test
+#      script:
+#        - tox
+#
+#
+#stages:
+#  - test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,31 +7,14 @@ matrix:
   include:
     - python: 3.6
       env: TOXENV=black
-  
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+
 install:
   - pip install tox
 
 
 script:
   - tox
-  -
-## Config file for automatic testing at travis-ci.org
-#jobs:
-#  include:
-#    - stage: test
-#      language: python
-#      python:
-#        - 3.6
-#        - 3.7
-#
-#      # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-#      install:
-#        - pip install --progress-bar off -U tox-travis
-#
-#      # Command to run tests, e.g. python setup.py test
-#      script:
-#        - tox
-#
-#
-#stages:
-#  - test

--- a/mlbench_core/api.py
+++ b/mlbench_core/api.py
@@ -462,7 +462,9 @@ class ApiClient(object):
         else:
             raise ValueError("Image {image} not found".format(image=image))
 
-        assert not ((custom_backend is not None) and (backend is not None)), "custom_backend and backend are mutually exclusive"
+        assert not (
+            (custom_backend is not None) and (backend is not None)
+        ), "custom_backend and backend are mutually exclusive"
         if custom_backend is not None:
             data["backend"] = "custom_backend"
             data["custom_backend"] = custom_backend

--- a/mlbench_core/cli/cli.py
+++ b/mlbench_core/cli/cli.py
@@ -139,7 +139,9 @@ def run(name, num_workers, gpu, light, dashboard_url):
 
     # Backend Prompt
     text_prompt = "Backend: \n\n"
-    text_prompt += "\n".join("[{}]\t{}".format(i, t) for i, t in enumerate(MLBENCH_BACKENDS))
+    text_prompt += "\n".join(
+        "[{}]\t{}".format(i, t) for i, t in enumerate(MLBENCH_BACKENDS)
+    )
     text_prompt += "\n[{}]\tCustom Backend".format(len(MLBENCH_BACKENDS))
     text_prompt += "\n\nSelection"
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,29 +1,51 @@
 [tox]
 envlist =  py36, py37, black
 
-[travis]
-python =
-    3.7: py37
-    3.6: py36
+[default]
+basepython = python3.6
 
-[testenv:black]
-basepython = python
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/travis-requirements.txt
-commands =
-    pip install -U pip
-    py.test --basetemp={envtmpdir} --black
 
-[testenv]
 setenv =
     PYTHONPATH = {toxinidir}
-deps =
-    -r{toxinidir}/requirements.txt
-    -r{toxinidir}/travis-requirements.txt
+
+[testenv]
+description = run tests
+
+basepython =
+    py36: python3.6
+    py37: python3.7
+
+    pypy3: pypy3
+
+deps = {[default]deps}
+
+setenv =
+    {[default]setenv}
 ; If you want to make tox run the tests with the same versions, create a
 ; requirements.txt with the pinned versions and uncomment the following line:
 ;     -r{toxinidir}/requirements.txt
 commands =
     pip install -U pip
     py.test --basetemp={envtmpdir}
+
+
+[testenv:black]
+
+description = run Black (linter)
+
+basepython = {[default]basepython}
+
+skip_install = True
+
+deps =
+    black==19.10b0
+
+setenv =
+    BLACK_LINT_ARGS=--check
+
+commands =
+    black {env:BLACK_LINT_ARGS:} mlbench_core
+

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ basepython = {[default]basepython}
 skip_install = True
 
 deps =
-    black==19.10b0
+    black
 
 setenv =
     BLACK_LINT_ARGS=--check


### PR DESCRIPTION
Fixes the CI that used to run only in python 3.6.

It now runs the `black` check and tests in both envs.

Closes #65 
Closes #35 