### PR TITLE
Refactor Controlflow

### DIFF
--- a/docs/controlflow.rst
+++ b/docs/controlflow.rst
@@ -10,13 +10,41 @@ pytorch
 .. autoapimodule:: mlbench_core.controlflow.pytorch
 .. currentmodule:: mlbench_core.controlflow.pytorch
 
-TrainValidation
-+++++++++++++++
+Controlflow
++++++++++++
 
-.. autoapiclass:: TrainValidation
+.. autoapifunction:: validation_round
+
+.. autoapifunction:: record_train_batch_stats
+
+.. autoapifunction:: record_validation_stats
+
+CheckpointsEvaluationControlFlow
+++++++++++++++++++++++++++++++++
+
+.. autoapiclass:: CheckpointsEvaluationControlFlow
+    :members:
+
+TrainValidation (Deprecated)
+++++++++++++++++++++++++++++
+
+.. autoapiclass:: mlbench_core.controlflow.pytorch.train_validation.TrainValidation
     :members:
 
     .. autoapimethod:: __call__
+
+Helpers
++++++++
+
+.. autoapimodule:: mlbench_core.controlflow.pytorch.helpers
+.. currentmodule:: mlbench_core.controlflow.pytorch.helpers
+
+.. autoapifunction:: maybe_range
+.. autoapifunction:: convert_dtype
+.. autoapifunction:: prepare_batch
+.. autoapifunction:: iterate_dataloader
+
+
 
 tensorflow
 ~~~~~~~~~~

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -9,13 +9,6 @@ pytorch
 .. autoapimodule:: mlbench_core.utils.pytorch
 .. currentmodule:: mlbench_core.utils.pytorch
 
-Timeit
-''''''
-
-.. autoapiclass:: Timeit
-    :members:
-
-
 
 FCGraph
 '''''''
@@ -27,6 +20,43 @@ initialize_backends
 '''''''''''''''''''
 
 .. autoapifunction:: initialize_backends
+
+
+Checkpointer
+''''''''''''
+
+.. autoapimodule:: mlbench_core.utils.pytorch.checkpoint
+.. currentmodule:: mlbench_core.utils.pytorch.checkpoint
+
+.. autoapiclass:: Checkpointer
+
+
+Distributed
+'''''''''''
+
+.. autoapimodule:: mlbench_core.utils.pytorch.distributed
+.. currentmodule:: mlbench_core.utils.pytorch.distributed
+
+.. autoapiclass:: Aggregation
+    :members:
+    :private-members:
+    :undoc-members:
+
+.. autoapiclass:: AllReduceAggregation
+    :show-inheritance:
+    :private-members:
+
+.. autoapiclass:: DecentralizedAggregation
+    :show-inheritance:
+    :private-members:
+
+.. autoapiclass:: SparsifiedAggregation
+    :show-inheritance:
+    :private-members:
+
+.. autoapifunction:: pack_tensors
+
+.. autoapifunction:: unpack_tensors
 
 tensorflow
 ~~~~~~~~~~

--- a/mlbench_core/controlflow/pytorch/__init__.py
+++ b/mlbench_core/controlflow/pytorch/__init__.py
@@ -1,15 +1,15 @@
 from .checkpoints_evaluation import CheckpointsEvaluationControlFlow
 from .controlflow import (
-    prepare_batch,
     record_train_batch_stats,
     record_validation_stats,
     validation_round,
 )
+from .helpers import prepare_batch
 
 __all__ = [
     "CheckpointsEvaluationControlFlow",
-    "prepare_batch",
     "record_validation_stats",
     "record_train_batch_stats",
     "validation_round",
+    "prepare_batch",
 ]

--- a/mlbench_core/controlflow/pytorch/__init__.py
+++ b/mlbench_core/controlflow/pytorch/__init__.py
@@ -1,15 +1,15 @@
 from .checkpoints_evaluation import CheckpointsEvaluationControlFlow
 from .controlflow import (
-    TrainValidation,
+    prepare_batch,
     record_train_batch_stats,
-    train_round,
+    record_validation_stats,
     validation_round,
 )
 
 __all__ = [
-    "TrainValidation",
     "CheckpointsEvaluationControlFlow",
-    "train_round",
-    "validation_round",
+    "prepare_batch",
+    "record_validation_stats",
     "record_train_batch_stats",
+    "validation_round",
 ]

--- a/mlbench_core/controlflow/pytorch/__init__.py
+++ b/mlbench_core/controlflow/pytorch/__init__.py
@@ -1,9 +1,15 @@
-from .controlflow import TrainValidation, train_round, validation_round
 from .checkpoints_evaluation import CheckpointsEvaluationControlFlow
+from .controlflow import (
+    TrainValidation,
+    record_train_batch_stats,
+    train_round,
+    validation_round,
+)
 
 __all__ = [
     "TrainValidation",
     "CheckpointsEvaluationControlFlow",
     "train_round",
     "validation_round",
+    "record_train_batch_stats",
 ]

--- a/mlbench_core/controlflow/pytorch/checkpoints_evaluation.py
+++ b/mlbench_core/controlflow/pytorch/checkpoints_evaluation.py
@@ -1,11 +1,10 @@
 """Evaluate training/validation set using models in checkpoints"""
 import logging
 
-from mlbench_core.utils.pytorch.distributed import AllReduceAggregation
-from mlbench_core.utils.pytorch.distributed import global_average
-from mlbench_core.utils.pytorch.helpers import iterate_dataloader
-
 import torch
+
+from mlbench_core.controlflow.pytorch.helpers import iterate_dataloader
+from mlbench_core.utils.pytorch.distributed import AllReduceAggregation, global_average
 
 logger = logging.getLogger("mlbench")
 

--- a/mlbench_core/controlflow/pytorch/controlflow.py
+++ b/mlbench_core/controlflow/pytorch/controlflow.py
@@ -2,21 +2,44 @@ r"""Control flow for pytorch applications."""
 import logging
 
 import torch
-import torch.distributed as dist
 
-from mlbench_core.utils import AverageMeter, Tracker
+from mlbench_core.utils import AverageMeter
 from mlbench_core.utils.pytorch.distributed import global_average
-from mlbench_core.utils.pytorch.helpers import iterate_dataloader
+from mlbench_core.utils.pytorch.helpers import convert_dtype, maybe_range
 
 logger = logging.getLogger("mlbench")
 
 LOG_EVERY_N_BATCHES = 25
 
 
+def prepare_batch(data, target, dtype, transform_target_dtype=False, use_cuda=False):
+    """Prepares a batch for training by changing the type and sending to cuda
+    if necessary
+
+    Args:
+        data (`obj`:torch.Tensor): The input tensor
+        target (`obj`:torch.Tensor): The target tensor
+        dtype (str): One of `fp32` or `fp64`, data type to transform input and/or target
+        transform_target_dtype (bool): Transform target to `dtype` too
+        use_cuda (bool): Send tensors to GPU
+
+    Returns:
+        (`obj`:torch.Tensor, `obj`:torch.Tensor): Input and target tensors
+    """
+    data = convert_dtype(dtype, data)
+    if transform_target_dtype:
+        target = convert_dtype(dtype, target)
+
+    if use_cuda:
+        data, target = data.cuda(), target.cuda()
+
+    return data, target
+
+
 def record_train_batch_stats(
     batch_idx, loss, output, target, metrics, tracker, num_batches_per_device_train
 ):
-    r"""Record the stats in a training batch.
+    """Record the stats in a training batch.
 
     Args:
         batch_idx (int): The id of the current batch
@@ -52,106 +75,16 @@ def record_train_batch_stats(
     logger.info(status + str(tracker))
 
 
-def train_round(
+def validation_round(
     dataloader,
     model,
-    optimizer,
     loss_function,
     metrics,
-    scheduler,
     dtype,
-    schedule_per="epoch",
-    transform_target_type=None,
-    use_cuda=False,
-    max_batch_per_epoch=None,
     tracker=None,
-):
-    """ Performs max_batch_per_epoch batches of training (or full trainset if
-    not specified)
-
-    Args:
-        dataloader (:obj:`torch.utils.data.DataLoader`): The train set
-        model (`obj`:torch.nn.Module): The model to train
-        optimizer (`obj`:torch.optim): The optimizer
-        loss_function (`obj`:torch.nn.Module): The loss function
-        metrics (list): List of metrics to track
-        scheduler (`obj`:torch.optim.lr_scheduler): Learning Rate scheduler
-        dtype (str): The datatype to use, one of `fp32`or `fp64`
-        schedule_per (str): Learning Rate scheduler mode, one of `batch` or `epoch`
-        transform_target_type (str): Datatype to convert data to, default: `None`
-        use_cuda (bool): Whether to use GPU for training, default: `False`
-        max_batch_per_epoch (int): Maximum number of batches tot rain for per epoch,
-                                   default: `None` (all batches)
-        tracker (`obj`:mlbench_core.utils.Tracker): Tracker object to use.
-    """
-    model.train()
-
-    if tracker:
-        tracker.train()
-
-    data_iter = iterate_dataloader(
-        dataloader, dtype, max_batch_per_epoch, use_cuda, transform_target_type
-    )
-
-    num_batches_per_device_train = len(dataloader)
-
-    for batch_idx, (data, target) in enumerate(data_iter):
-        if tracker:
-            tracker.batch_start()
-
-        # Clear gradients in the optimizer.
-        optimizer.zero_grad()
-        if tracker:
-            tracker.record_batch_init()
-
-        # Compute the output
-        output = model(data)
-        if tracker:
-            tracker.record_batch_fwd_pass()
-
-        # Compute the loss
-        loss = loss_function(output, target)
-        if tracker:
-            tracker.record_batch_comp_loss()
-
-        # Backprop
-        loss.backward()
-        if tracker:
-            tracker.record_batch_backprop()
-
-        # Aggregate gradients/parameters from all workers and apply updates to model
-        optimizer.step()
-        if tracker:
-            tracker.record_batch_opt_step()
-
-        if schedule_per == "batch":
-            scheduler.step()
-
-        if tracker:
-            tracker.batch_end()
-
-        record_train_batch_stats(
-            batch_idx,
-            loss.item(),
-            output,
-            target,
-            metrics,
-            tracker,
-            num_batches_per_device_train,
-        )
-    if schedule_per == "epoch":
-        scheduler.step()
-
-
-def _validate(
-    dataloader,
-    model,
-    loss_function,
-    metrics,
-    dtype,
-    transform_target_type=None,
+    transform_target_type=False,
     use_cuda=False,
-    max_batch_per_epoch=None,
+    max_batches=None,
 ):
     """Evaluate the model on the test dataset.
 
@@ -161,11 +94,21 @@ def _validate(
         loss_function (`obj`:torch.nn.Module): The loss function
         metrics (list): List of metrics to track
         dtype (str): The datatype to use, one of `fp32`or `fp64`
-        transform_target_type (str | None): Datatype to convert data to, default: `None`
+        tracker (`obj`:mlbench_core.utils.Tracker | None): Tracker object to use.
+        transform_target_type (bool): Convert target to `dtype`. Default `False`
         use_cuda (bool): Whether to use GPU for training, default: `False`
-        max_batch_per_epoch (int | None): Maximum number of batches tot rain for per epoch,
-                                   default: `None` (all batches)
-        """
+        max_batches (int | None): Maximum number of batches to validate on
+
+    Returns:
+          (dict, float): Dictionary of average of each metric, and average validation loss
+    """
+
+    model.eval()
+
+    if tracker:
+        tracker.validation()
+
+        tracker.validation_start()
     # Initialize the accumulators for loss and metrics
     losses = AverageMeter()
     for metric in metrics:
@@ -173,11 +116,11 @@ def _validate(
 
     # Each worker computer their own losses and metrics
     with torch.no_grad():
-        data_iter = iterate_dataloader(
-            dataloader, dtype, max_batch_per_epoch, use_cuda, transform_target_type
-        )
 
-        for data, target in data_iter:
+        for _, (data, target) in zip(maybe_range(max_batches), dataloader):
+            data, target = prepare_batch(
+                data, target, dtype, transform_target_type, use_cuda
+            )
             # Inference
             output = model(data)
 
@@ -198,56 +141,18 @@ def _validate(
     return metrics_averages, loss_average
 
 
-def validation_round(
-    dataloader,
-    model,
-    loss_function,
-    metrics,
-    run_id,
-    rank,
-    dtype,
-    transform_target_type=None,
-    use_cuda=False,
-    max_batch_per_epoch=None,
-    tracker=None,
-):
-    """ Handles one full iteration of validation on the whole validation set.
+def record_validation_stats(metrics_values, loss, tracker=None, rank=0):
+    """Records the stats of a previously run validation
 
     Args:
-        dataloader (:obj:`torch.utils.data.DataLoader`): The validation set
-        model (`obj`:torch.nn.Module): The model to train
-        loss_function (`obj`:torch.nn.Module): The loss function
-        metrics (list): List of metrics to track
-        run_id (int): The id of the current run
-        rank (int): The rank of the current worker node
-        dtype (str): The datatype to use, one of `fp32`or `fp64`
-        transform_target_type (str): Datatype to convert data to, default: `None`
-        use_cuda (bool): Whether to use GPU for training, default: `False`
-        max_batch_per_epoch (int): Maximum number of batches tot rain for per epoch,
-                                   default: `None` (all batches)
-        tracker (`obj`:mlbench_core.utils.Tracker): Tracker object to use. Will be
-                                                    created if not supplied
+        metrics_values (dict): Dictionary of each metric's average.
+        loss (float): Validation loss
+        tracker (`obj`:mlbench_core.utils.Tracker | None): Tracker object to use.
+        rank (int): Current distributed rank
+
+    Returns:
+        (bool): Whether this validation round is the best
     """
-    model.eval()
-
-    if tracker:
-        tracker.validation()
-
-        tracker.validation_start()
-
-    metrics_values, loss = _validate(
-        dataloader,
-        model,
-        loss_function,
-        metrics,
-        dtype,
-        transform_target_type,
-        use_cuda,
-        max_batch_per_epoch,
-    )
-    if tracker:
-        tracker.validation_end()
-
     if len(metrics_values) > 0:
         # Save
         if tracker:
@@ -286,209 +191,3 @@ def validation_round(
             tracker.record_stat("global_loss", global_loss, log_to_api=True)
 
     return tracker.is_best() if tracker else False
-
-
-class TrainValidation(object):
-    r"""Train and validate a model.
-
-    Args:
-        model (:obj:`torch.nn.Module`): a pytorch model to be trained and validated.
-        optimizer (:obj:`torch.optim.Optimizer`): an optimizer for the given model.
-        loss_function (:obj:`torch.nn.modules.loss._Loss`): loss function.
-        metrics (:obj:`list` of :obj:`mlbench_core.evaluation.pytorch.*`): metrics like TopKAccuracy.
-        scheduler (:obj:`mlbench_core.lr_scheduler.pytorch.lr.*`): a scheduler for hyperparameters.
-        batch_size (int): The size of batches provided by the dataloader
-        train_epochs (int): The number of epochs to train for
-        rank (int): The rank of the current workers
-        world_size (int): The total number of workers
-        run_id (str): The id of the current run
-        dtype (str): The datatype to use for the dataloader data
-        validate (bool): Whether to run validation on the val dataset. Default: `True`
-        schedule_per (str): When to perform a step for the lr scheduler, one of
-            `epoch` or `batch`. Default: `epoch`
-        checkpoint (:obj:`Checkpointer`): Class that handles checkpointing. Default: `None`
-        transform_target_type (str): dtype to transform the target to. Not used. Default: `None`
-        average_models (bool): Whether to average models together. Default: `False`
-        use_cuda (bool): Whether to train on GPU or not. Default: `False`
-        max_batch_per_epoch (int): Maximum number of batches per epoch. Whole dataset
-            is used if not specified. Default: `None`
-        tracker (:obj:`mlbench_core.utils.Tracker`): Tracker for the controlflow. Default: `None`
-    """
-
-    def __init__(
-        self,
-        model,
-        optimizer,
-        loss_function,
-        metrics,
-        scheduler,
-        batch_size,
-        train_epochs,
-        rank,
-        world_size,
-        run_id,
-        dtype,
-        validate=True,
-        schedule_per="epoch",
-        checkpoint=None,
-        transform_target_type=None,
-        average_models=False,
-        use_cuda=False,
-        max_batch_per_epoch=None,
-        tracker=None,
-    ):
-        self.batch_size = batch_size
-        self.train_epochs = train_epochs
-        self.model = model
-        self.optimizer = optimizer
-        self.scheduler = scheduler
-        self.schedule_per = schedule_per
-        self.perform_validation = validate
-        self.checkpoint = checkpoint
-        self.model = model
-        self.optimizer = optimizer
-        self.loss_function = loss_function
-        self.metrics = metrics
-        self.scheduler = scheduler
-        self.batch_size = batch_size
-        self.rank = rank
-        self.run_id = run_id
-        self.dtype = dtype
-        self.schedule_per = schedule_per
-        self.transform_target_type = transform_target_type
-        self.use_cuda = use_cuda
-        self.max_batch_per_epoch = max_batch_per_epoch
-        if tracker:
-            self.tracker = tracker
-        else:
-            self.tracker = Tracker(metrics, run_id, rank)
-
-    def _get_dataloader_stats(self, dataloader_train, dataloader_val):
-        """ Sets the stats for the supplied dataloaders
-
-        Args:
-            dataloader_train (:obj:`torch.utils.data.DataLoader`): The train set
-            dataloader_val (:obj:`torch.utils.data.DataLoader`): The validation set
-        """
-        self.num_batches_per_device_train = len(dataloader_train)
-        self.num_batches_per_device_val = len(dataloader_val)
-
-    def run(
-        self,
-        dataloader_train=None,
-        dataloader_val=None,
-        dataloader_train_fn=None,
-        dataloader_val_fn=None,
-        resume=False,
-        repartition_per_epoch=False,
-    ):
-        """Execute training and (possibly) validation
-
-        `dataloader_train` and `dataloader_train_fn` are mutually exclusive.
-        `dataloader_val` and `dataloader_val_fn` are mutually exclusive.
-
-        Args:
-            dataloader_train (:obj:`torch.utils.data.DataLoader`): A dataloader for the train set.
-                Default: `None`
-            dataloader_val (:obj:`torch.utils.data.DataLoader`): A dataloader for the val set.
-                Default: `None`
-            dataloader_train_fn (:func:`Function`): A function returning a :obj:`torch.utils.data.DataLoader`
-                for the train set. Default: `None`
-            dataloader_val_fn (:func:`Function`): A function returning a :obj:`torch.utils.data.DataLoader`
-                for the val set. Default: `None`
-            resume (bool): Whether this is a resume of a previous run or not. Default: `False`
-            repartition_per_epoch (bool): Whether to repartition the dataset again every epoch.
-                Requires dataloader_train_fn and/or dataloader_val_fn to be set. Default: `False`
-        """
-
-        if not dataloader_train_fn and not dataloader_train:
-            raise ValueError(
-                "One of dataloader_train_fn or dataloader_train must be set"
-            )
-
-        if not dataloader_val_fn and not dataloader_val:
-            raise ValueError("One of dataloader_val_fn or dataloader_val must be set")
-
-        if dataloader_train_fn:
-            dataloader_train = dataloader_train_fn()
-
-        if dataloader_val_fn:
-            dataloader_val = dataloader_val_fn()
-
-        self._get_dataloader_stats(dataloader_train, dataloader_val)
-
-        # define some parameters for training.
-        logger.info(
-            "There are {train_epochs} epochs, {num_batches} "
-            "mini-batches per epoch (batch size: {batch_size}).".format(
-                train_epochs=self.train_epochs,
-                num_batches=self.num_batches_per_device_train,
-                batch_size=self.batch_size,
-            )
-        )
-
-        # Initialize Tracker or resume from checkpoint
-        if resume:
-            start_epoch = self.tracker.current_epoch + 1
-        else:
-            start_epoch = 0
-
-        dist.barrier()
-        for epoch in range(start_epoch, self.train_epochs):
-            # Per epoch information.
-            logger.info(
-                "Current epoch : {} : lr={}".format(epoch, self.scheduler.get_lr())
-            )
-
-            train_round(
-                dataloader_train,
-                self.model,
-                self.optimizer,
-                self.loss_function,
-                self.metrics,
-                self.scheduler,
-                self.dtype,
-                self.schedule_per,
-                self.transform_target_type,
-                self.use_cuda,
-                self.max_batch_per_epoch,
-                self.tracker,
-            )
-
-            is_best = False
-            if self.perform_validation:
-                is_best = validation_round(
-                    dataloader_val,
-                    self.model,
-                    self.loss_function,
-                    self.metrics,
-                    self.run_id,
-                    self.rank,
-                    self.dtype,
-                    self.transform_target_type,
-                    self.use_cuda,
-                    self.max_batch_per_epoch,
-                    self.tracker,
-                )
-
-            if self.checkpoint:
-                self.checkpoint.save(
-                    self.tracker,
-                    self.model,
-                    self.optimizer,
-                    self.scheduler,
-                    self.tracker.current_epoch,
-                    is_best,
-                )
-
-            # Shuffle the dataset across nodes
-            if repartition_per_epoch:
-                if dataloader_train_fn:
-                    dataloader_train = dataloader_train_fn()
-
-                if dataloader_val_fn:
-                    dataloader_val = dataloader_val_fn()
-
-                self._get_dataloader_stats(dataloader_train, dataloader_val)
-
-            self.tracker.epoch_end()

--- a/mlbench_core/controlflow/pytorch/controlflow.py
+++ b/mlbench_core/controlflow/pytorch/controlflow.py
@@ -80,11 +80,10 @@ def validation_round(
     """
 
     model.eval()
-
     if tracker:
         tracker.validation()
-
         tracker.validation_start()
+
     # Initialize the accumulators for loss and metrics
     losses = AverageMeter()
     for metric in metrics:
@@ -114,6 +113,9 @@ def validation_round(
     # Aggregate metrics and loss for all workers
     metrics_averages = {metric: metric.average().item() for metric in metrics}
     loss_average = global_average(losses.sum, losses.count).item()
+
+    if tracker:
+        tracker.validation_end()
     return metrics_averages, loss_average
 
 

--- a/mlbench_core/controlflow/pytorch/helpers.py
+++ b/mlbench_core/controlflow/pytorch/helpers.py
@@ -1,0 +1,97 @@
+import itertools
+
+
+def maybe_range(maximum):
+    """Map an integer or None to an integer iterator starting from 0 with stride 1.
+
+    If maximum number of batches per epoch is limited, then return an finite
+    iterator. Otherwise, return an iterator of infinite length.
+
+    Args:
+        maximum (int | None): Maximum number of steps in iterator.
+            If none, returns iterator of infinite length
+
+    Returns:
+        (iterator)
+    """
+    if maximum is None:
+        counter = itertools.count(0)
+    else:
+        counter = range(maximum)
+    return counter
+
+
+def convert_dtype(dtype, obj):
+    """Converts given tensor to given dtype
+
+    Args:
+        dtype (str): One of `fp32` or `fp64`
+        obj (`obj`:torch.Tensor | `obj`:torch.nn.Module): Module or tensor to convert
+
+    Returns:
+        (`obj`:torch.Tensor | `obj`:torch.nn.Module): Converted tensor or module
+    """
+    # The object should be a ``module`` or a ``tensor``
+    if dtype == "fp32":
+        return obj.float()
+    elif dtype == "fp64":
+        return obj.double()
+    else:
+        raise NotImplementedError("dtype {} not supported.".format(dtype))
+
+
+def prepare_batch(data, target, dtype, transform_target_dtype=False, use_cuda=False):
+    """Prepares a batch for training by changing the type and sending to cuda
+    if necessary
+
+    Args:
+        data (`obj`:torch.Tensor): The input tensor
+        target (`obj`:torch.Tensor): The target tensor
+        dtype (str): One of `fp32` or `fp64`, data type to transform input and/or target
+        transform_target_dtype (bool): Transform target to `dtype` too
+        use_cuda (bool): Send tensors to GPU
+
+    Returns:
+        (`obj`:torch.Tensor, `obj`:torch.Tensor): Input and target tensors
+    """
+    data = convert_dtype(dtype, data)
+    if transform_target_dtype:
+        target = convert_dtype(dtype, target)
+
+    if use_cuda:
+        data, target = data.cuda(), target.cuda()
+
+    return data, target
+
+
+def iterate_dataloader(
+    dataloader,
+    dtype,
+    max_batch_per_epoch=None,
+    use_cuda=False,
+    transform_target_type=False,
+):
+    """Function that returns an iterator on the given loader.
+    Can be used to limit the number of batches, converting input and target dtypes
+    and sending to GPU
+
+    Args:
+        dataloader (`obj`:torch.utils.data.DataLoader): The loader
+        dtype (str): Type to convert to (`fp32` or `fp64`)
+        max_batch_per_epoch (int | None): Maximum number of batches
+        use_cuda (bool): Send tensors to GPU
+        transform_target_type (bool): Transform target dtype as well
+
+    Returns:
+        (iterator): An iterator over the data
+    """
+    for _, (data, target) in zip(maybe_range(max_batch_per_epoch), dataloader):
+        data, target = prepare_batch(
+            data=data,
+            target=target,
+            dtype=dtype,
+            transform_target_dtype=transform_target_type,
+            use_cuda=use_cuda,
+        )
+
+        yield data, target

--- a/mlbench_core/controlflow/pytorch/train_validation.py
+++ b/mlbench_core/controlflow/pytorch/train_validation.py
@@ -1,0 +1,309 @@
+"""Deprecated class, please use functions in `controlflow.py`"""
+
+import logging
+
+from torch import distributed as dist
+
+from mlbench_core.utils import Tracker
+from mlbench_core.utils.pytorch.helpers import iterate_dataloader
+
+from . import record_train_batch_stats, record_validation_stats, validation_round
+
+logger = logging.getLogger("mlbench")
+
+
+class TrainValidation(object):
+    r"""Train and validate a model.
+
+    Args:
+        model (:obj:`torch.nn.Module`): a pytorch model to be trained and validated.
+        optimizer (:obj:`torch.optim.Optimizer`): an optimizer for the given model.
+        loss_function (:obj:`torch.nn.modules.loss._Loss`): loss function.
+        metrics (:obj:`list` of :obj:`mlbench_core.evaluation.pytorch.*`): metrics like TopKAccuracy.
+        scheduler (:obj:`mlbench_core.lr_scheduler.pytorch.lr.*`): a scheduler for hyperparameters.
+        batch_size (int): The size of batches provided by the dataloader
+        train_epochs (int): The number of epochs to train for
+        rank (int): The rank of the current workers
+        world_size (int): The total number of workers
+        run_id (str): The id of the current run
+        dtype (str): The datatype to use for the dataloader data
+        validate (bool): Whether to run validation on the val dataset. Default: `True`
+        schedule_per (str): When to perform a step for the lr scheduler, one of
+            `epoch` or `batch`. Default: `epoch`
+        checkpoint (:obj:`Checkpointer`): Class that handles checkpointing. Default: `None`
+        transform_target_type (str): dtype to transform the target to. Not used. Default: `None`
+        average_models (bool): Whether to average models together. Default: `False`
+        use_cuda (bool): Whether to train on GPU or not. Default: `False`
+        max_batch_per_epoch (int): Maximum number of batches per epoch. Whole dataset
+            is used if not specified. Default: `None`
+        tracker (:obj:`mlbench_core.utils.Tracker`): Tracker for the controlflow. Default: `None`
+    """
+
+    def __init__(
+        self,
+        model,
+        optimizer,
+        loss_function,
+        metrics,
+        scheduler,
+        batch_size,
+        train_epochs,
+        rank,
+        world_size,
+        run_id,
+        dtype,
+        validate=True,
+        schedule_per="epoch",
+        checkpoint=None,
+        transform_target_type=None,
+        average_models=False,
+        use_cuda=False,
+        max_batch_per_epoch=None,
+        tracker=None,
+    ):
+        self.batch_size = batch_size
+        self.train_epochs = train_epochs
+        self.model = model
+        self.optimizer = optimizer
+        self.scheduler = scheduler
+        self.schedule_per = schedule_per
+        self.perform_validation = validate
+        self.checkpoint = checkpoint
+        self.model = model
+        self.optimizer = optimizer
+        self.loss_function = loss_function
+        self.metrics = metrics
+        self.scheduler = scheduler
+        self.batch_size = batch_size
+        self.rank = rank
+        self.run_id = run_id
+        self.dtype = dtype
+        self.schedule_per = schedule_per
+        self.transform_target_type = transform_target_type
+        self.use_cuda = use_cuda
+        self.max_batch_per_epoch = max_batch_per_epoch
+        if tracker:
+            self.tracker = tracker
+        else:
+            self.tracker = Tracker(metrics, run_id, rank)
+
+    def _get_dataloader_stats(self, dataloader_train, dataloader_val):
+        """ Sets the stats for the supplied dataloaders
+
+        Args:
+            dataloader_train (:obj:`torch.utils.data.DataLoader`): The train set
+            dataloader_val (:obj:`torch.utils.data.DataLoader`): The validation set
+        """
+        self.num_batches_per_device_train = len(dataloader_train)
+        self.num_batches_per_device_val = len(dataloader_val)
+
+    def run(
+        self,
+        dataloader_train=None,
+        dataloader_val=None,
+        dataloader_train_fn=None,
+        dataloader_val_fn=None,
+        resume=False,
+        repartition_per_epoch=False,
+    ):
+        """Execute training and (possibly) validation
+
+        `dataloader_train` and `dataloader_train_fn` are mutually exclusive.
+        `dataloader_val` and `dataloader_val_fn` are mutually exclusive.
+
+        Args:
+            dataloader_train (:obj:`torch.utils.data.DataLoader`): A dataloader for the train set.
+                Default: `None`
+            dataloader_val (:obj:`torch.utils.data.DataLoader`): A dataloader for the val set.
+                Default: `None`
+            dataloader_train_fn (:func:`Function`): A function returning a :obj:`torch.utils.data.DataLoader`
+                for the train set. Default: `None`
+            dataloader_val_fn (:func:`Function`): A function returning a :obj:`torch.utils.data.DataLoader`
+                for the val set. Default: `None`
+            resume (bool): Whether this is a resume of a previous run or not. Default: `False`
+            repartition_per_epoch (bool): Whether to repartition the dataset again every epoch.
+                Requires dataloader_train_fn and/or dataloader_val_fn to be set. Default: `False`
+        """
+
+        if not dataloader_train_fn and not dataloader_train:
+            raise ValueError(
+                "One of dataloader_train_fn or dataloader_train must be set"
+            )
+
+        if not dataloader_val_fn and not dataloader_val:
+            raise ValueError("One of dataloader_val_fn or dataloader_val must be set")
+
+        if dataloader_train_fn:
+            dataloader_train = dataloader_train_fn()
+
+        if dataloader_val_fn:
+            dataloader_val = dataloader_val_fn()
+
+        self._get_dataloader_stats(dataloader_train, dataloader_val)
+
+        # define some parameters for training.
+        logger.info(
+            "There are {train_epochs} epochs, {num_batches} "
+            "mini-batches per epoch (batch size: {batch_size}).".format(
+                train_epochs=self.train_epochs,
+                num_batches=self.num_batches_per_device_train,
+                batch_size=self.batch_size,
+            )
+        )
+
+        # Initialize Tracker or resume from checkpoint
+        if resume:
+            start_epoch = self.tracker.current_epoch + 1
+        else:
+            start_epoch = 0
+
+        dist.barrier()
+        for epoch in range(start_epoch, self.train_epochs):
+            # Per epoch information.
+            logger.info(
+                "Current epoch : {} : lr={}".format(epoch, self.scheduler.get_lr())
+            )
+
+            train_round(
+                dataloader_train,
+                self.model,
+                self.optimizer,
+                self.loss_function,
+                self.metrics,
+                self.scheduler,
+                self.dtype,
+                self.schedule_per,
+                self.transform_target_type,
+                self.use_cuda,
+                self.max_batch_per_epoch,
+                self.tracker,
+            )
+
+            is_best = False
+            if self.perform_validation:
+                metrics, loss = validation_round(
+                    dataloader_val,
+                    self.model,
+                    self.loss_function,
+                    self.metrics,
+                    self.dtype,
+                    self.tracker,
+                    self.transform_target_type,
+                    self.use_cuda,
+                )
+                is_best = record_validation_stats(
+                    metrics, loss, self.tracker, self.rank
+                )
+
+            if self.checkpoint:
+                self.checkpoint.save(
+                    self.tracker,
+                    self.model,
+                    self.optimizer,
+                    self.scheduler,
+                    self.tracker.current_epoch,
+                    is_best,
+                )
+
+            # Shuffle the dataset across nodes
+            if repartition_per_epoch:
+                if dataloader_train_fn:
+                    dataloader_train = dataloader_train_fn()
+
+                if dataloader_val_fn:
+                    dataloader_val = dataloader_val_fn()
+
+                self._get_dataloader_stats(dataloader_train, dataloader_val)
+
+            self.tracker.epoch_end()
+
+
+def train_round(
+    dataloader,
+    model,
+    optimizer,
+    loss_function,
+    metrics,
+    scheduler,
+    dtype,
+    schedule_per="epoch",
+    transform_target_type=None,
+    use_cuda=False,
+    max_batch_per_epoch=None,
+    tracker=None,
+):
+    """ Performs max_batch_per_epoch batches of training (or full trainset if
+    not specified)
+
+    Args:
+        dataloader (:obj:`torch.utils.data.DataLoader`): The train set
+        model (`obj`:torch.nn.Module): The model to train
+        optimizer (`obj`:torch.optim): The optimizer
+        loss_function (`obj`:torch.nn.Module): The loss function
+        metrics (list): List of metrics to track
+        scheduler (`obj`:torch.optim.lr_scheduler): Learning Rate scheduler
+        dtype (str): The datatype to use, one of `fp32`or `fp64`
+        schedule_per (str): Learning Rate scheduler mode, one of `batch` or `epoch`
+        transform_target_type (str): Datatype to convert data to, default: `None`
+        use_cuda (bool): Whether to use GPU for training, default: `False`
+        max_batch_per_epoch (int): Maximum number of batches tot rain for per epoch,
+                                   default: `None` (all batches)
+        tracker (`obj`:mlbench_core.utils.Tracker): Tracker object to use.
+    """
+    model.train()
+
+    if tracker:
+        tracker.train()
+
+    data_iter = iterate_dataloader(
+        dataloader, dtype, max_batch_per_epoch, use_cuda, transform_target_type
+    )
+
+    num_batches_per_device_train = len(dataloader)
+
+    for batch_idx, (data, target) in enumerate(data_iter):
+        if tracker:
+            tracker.batch_start()
+
+        # Clear gradients in the optimizer.
+        optimizer.zero_grad()
+        if tracker:
+            tracker.record_batch_init()
+
+        # Compute the output
+        output = model(data)
+        if tracker:
+            tracker.record_batch_fwd_pass()
+
+        # Compute the loss
+        loss = loss_function(output, target)
+        if tracker:
+            tracker.record_batch_comp_loss()
+
+        # Backprop
+        loss.backward()
+        if tracker:
+            tracker.record_batch_backprop()
+
+        # Aggregate gradients/parameters from all workers and apply updates to model
+        optimizer.step()
+        if tracker:
+            tracker.record_batch_opt_step()
+
+        if schedule_per == "batch":
+            scheduler.step()
+
+        if tracker:
+            tracker.batch_end()
+
+        record_train_batch_stats(
+            batch_idx,
+            loss.item(),
+            output,
+            target,
+            metrics,
+            tracker,
+            num_batches_per_device_train,
+        )
+    if schedule_per == "epoch":
+        scheduler.step()

--- a/mlbench_core/controlflow/pytorch/train_validation.py
+++ b/mlbench_core/controlflow/pytorch/train_validation.py
@@ -5,9 +5,9 @@ import logging
 from torch import distributed as dist
 
 from mlbench_core.utils import Tracker
-from mlbench_core.utils.pytorch.helpers import iterate_dataloader
 
 from . import record_train_batch_stats, record_validation_stats, validation_round
+from .helpers import iterate_dataloader
 
 logger = logging.getLogger("mlbench")
 

--- a/mlbench_core/controlflow/pytorch/train_validation.py
+++ b/mlbench_core/controlflow/pytorch/train_validation.py
@@ -2,6 +2,7 @@
 
 import logging
 
+import deprecation
 from torch import distributed as dist
 
 from mlbench_core.utils import Tracker
@@ -12,6 +13,7 @@ from .helpers import iterate_dataloader
 logger = logging.getLogger("mlbench")
 
 
+@deprecation.deprecated()
 class TrainValidation(object):
     r"""Train and validate a model.
 

--- a/mlbench_core/models/pytorch/resnet.py
+++ b/mlbench_core/models/pytorch/resnet.py
@@ -22,7 +22,7 @@ for image net. Here we only implemented the remaining models
 for CIFAR-10 dataset. Besides, their implementation uses projection shortcut by default.
 
 """
-from mlbench_core.utils.pytorch.helpers import convert_dtype
+from mlbench_core.controlflow.pytorch.helpers import convert_dtype
 
 import torch
 import torch.nn as nn

--- a/mlbench_core/utils/pytorch/__init__.py
+++ b/mlbench_core/utils/pytorch/__init__.py
@@ -1,16 +1,13 @@
-import torch.distributed as dist
-from .helpers import config_logging
-from .helpers import config_pytorch
-from .helpers import config_path
-from .helpers import Timeit
-from .topology import FCGraph
-
+import os
 from contextlib import contextmanager
 
-import os
 import torch
+import torch.distributed as dist
 
-__all__ = ["initialize_backends", "Timeit", "FCGraph"]
+from .helpers import config_logging, config_path, config_pytorch
+from .topology import FCGraph
+
+__all__ = ["initialize_backends", "FCGraph"]
 
 
 @contextmanager

--- a/mlbench_core/utils/pytorch/distributed.py
+++ b/mlbench_core/utils/pytorch/distributed.py
@@ -1,28 +1,6 @@
 import torch
 import torch.distributed as dist
 
-# TODO: those 3 funtions are never used, maybe delete them ?
-
-
-def broadcast(tensor, src):
-    return dist.broadcast(tensor, src=src)
-
-
-def elementwise_min(tensor):
-    dist.all_reduce(tensor, op=dist.ReduceOp.MIN)
-    return tensor
-
-
-def aggregate_gradients(model, world_size, average_models=False):
-    """Average gradients of models across all processes."""
-    # all_reduce the gradients.
-    for ind, param in enumerate(model.parameters()):
-        # all reduce.
-        dist.all_reduce(param.grad.data, op=dist.ReduceOp.SUM)
-
-        if average_models:
-            param.grad.data /= world_size
-
 
 def global_average(sum, count):
     def helper(array):
@@ -191,7 +169,7 @@ class Aggregation(object):
 
 
 class AllReduceAggregation(Aggregation):
-    """Aggregate udpates / models from different processes."""
+    """Aggregate udpates / models from different processes using all-reduce aggregation"""
 
     def __init__(self, world_size, use_cuda=False):
         self.world_size = world_size

--- a/mlbench_core/utils/pytorch/helpers.py
+++ b/mlbench_core/utils/pytorch/helpers.py
@@ -1,101 +1,25 @@
 r"""Helper functions."""
 
-import datetime
-import itertools
 import logging
 import os
 import random
 import shutil
 import socket
-import time
 
-import deprecation
 import torch
-from mlbench_core.api import ApiClient
-from mlbench_core.utils.pytorch.topology import FCGraph
 from torch import distributed as dist
 
-
-class Timeit(object):
-    """Training Time Tracker
-
-    Used to track training time for timing comparison
-
-    Args:
-        cumu (float, optional): starting time in seconds. Default: ``0.0``
-
-    Example:
-        >>> t = Timeit()
-        >>> [... Do some training...]
-        >>> t.pause()
-        >>> [... do some non-training related things ...]
-        >>> t.resume()
-        >>> print(t.cumu)
-    """
-
-    def __init__(self, cumu=0):
-        self.t = time.time()
-        self._cumu = cumu
-        self._paused = False
-
-    def pause(self):
-        """ Pause Time Tracking"""
-        if not self._paused:
-            self._cumu += time.time() - self.t
-            self.t = time.time()
-            self._paused = True
-
-    def resume(self):
-        """ Resume Time Tracking"""
-        if self._paused:
-            self.t = time.time()
-            self._paused = False
-
-    @property
-    def cumu(self):
-        """ float: total tracked time in seconds"""
-        return self._cumu
-
-
-def maybe_range(maximum):
-    """Map an integer or None to an integer iterator starting from 0 with strid 1.
-
-    If maximum number of batches per epoch is limited, then return an finite
-    iterator. Otherwise, return an iterator of infinite length.
-    """
-    if maximum is None:
-        counter = itertools.count(0)
-    else:
-        counter = range(maximum)
-    return counter
-
-
-def update_best_runtime_metric(tracker, metric_value, metric_name):
-    """Update the runtime information to config if the metric value is the best."""
-    best_metric_name = "best_{}".format(metric_name)
-    is_best = metric_value > tracker.best_metric_value
-
-    if is_best:
-        tracker.best_metric_name = best_metric_name
-        tracker.best_metric_value = metric_value
-        tracker.best_epoch = tracker.current_epoch
-    return is_best, best_metric_name
-
-
-def convert_dtype(dtype, obj):
-    # The object should be a ``module`` or a ``tensor``
-    if dtype == "fp32":
-        return obj.float()
-    elif dtype == "fp64":
-        return obj.double()
-    else:
-        raise NotImplementedError("dtype {} not supported.".format(dtype))
+from mlbench_core.utils.pytorch.topology import FCGraph
 
 
 def config_logging(logging_level="INFO", logging_file="/mlbench.log"):
     """Setup logging modules.
-
     A stream handler and file handler are added to default logger `mlbench`.
+
+    Args:
+        logging_level (str): Log level
+        logging_file (str): Log file
+
     """
 
     class RankFilter(logging.Filter):
@@ -131,8 +55,13 @@ def config_pytorch(use_cuda=False, seed=None, cudnn_deterministic=False):
     Fix random number for packages and initialize distributed environment for pytorch.
     Setup cuda environment for pytorch.
 
-    :param config: A global object containing specified config.
-    :type config: argparse.Namespace
+    Args:
+        use_cuda (bool): Use CUDA acceleration
+        seed (int | None): Random seed to use
+        cudnn_deterministic (bool): Set `cudnn.determenistic=True`
+
+    Returns:
+        (int, int, `obj`:FCGraph): The rank, world size, and network graph
     """
     # Setting `cudnn.deterministic = True` will turn on
     # CUDNN deterministic setting which can slow down training considerably.
@@ -184,114 +113,9 @@ def config_pytorch(use_cuda=False, seed=None, cudnn_deterministic=False):
     return rank, world_size, graph
 
 
-@deprecation.deprecated(
-    deprecated_in="1.3.1",
-    details="This method was moved to mlbench_core.utils.log_metrics",
-)
-class LogMetrics(object):
-    in_cluster = os.getenv("KUBERNETES_SERVICE_HOST") is not None
-
-    if in_cluster:
-        api = ApiClient()
-
-    @staticmethod
-    def log(run_id, rank, epoch, metric_name, value, tracker=None, time=None):
-        if not LogMetrics.in_cluster:
-            return
-
-        metric_name = "{} @ {}".format(metric_name, rank)
-
-        LogMetrics.api.post_metric(
-            run_id,
-            metric_name,
-            value,
-            metadata="{{rank: {}, epoch:{}}}".format(rank, epoch),
-        )
-
-        if tracker and time:
-            tracker.records.append(
-                {
-                    "run_id": run_id,
-                    "name": metric_name,
-                    "cumulative": True,
-                    "date": str(datetime.datetime.now()),
-                    "time": str(time),
-                    "value": str(value),
-                    "metadata": "{{rank: {}, epoch:{}}}".format(rank, epoch),
-                }
-            )
-
-
-@deprecation.deprecated(
-    deprecated_in="1.1.1",
-    details="This method has performance implications, use"
-    " mlbench_core.utils.pytorch.helpers.LogMetrics instead",
-)
-def log_metrics(run_id, rank, epoch, metric_name, value, tracker=None, time=None):
-    """ Log metrics to mlbench master/dashboard
-
-    Args:
-        run_id (str): The id of the current run
-        rank (int): The rank of the current worker
-        epoch (int): The current epoch
-        metric_name (str): The name of the metric to save
-        value (Any): The metric value
-    """
-    in_cluster = os.getenv("MLBENCH_IN_DOCKER") is None
-
-    metric_name = "{} @ {}".format(metric_name, rank)
-
-    if in_cluster:
-        api = ApiClient()
-        api.post_metric(
-            run_id,
-            metric_name,
-            value,
-            metadata="{{rank: {}, epoch:{}}}".format(rank, epoch),
-        )
-
-    if tracker and time:
-        tracker.records.append(
-            {
-                "run_id": run_id,
-                "name": metric_name,
-                "cumulative": True,
-                "date": str(datetime.datetime.now()),
-                "time": str(time),
-                "value": str(value),
-                "metadata": "{{rank: {}, epoch:{}}}".format(rank, epoch),
-            }
-        )
-
-
 def config_path(ckpt_run_dir, delete_existing_ckpts=False):
     """Config the path used during the experiments."""
     if delete_existing_ckpts:
         print("Remove previous checkpoint directory : {}".format(ckpt_run_dir))
         shutil.rmtree(ckpt_run_dir, ignore_errors=True)
     os.makedirs(ckpt_run_dir, exist_ok=True)
-
-
-def iterate_dataloader(
-    dataloader,
-    dtype,
-    max_batch_per_epoch=None,
-    use_cuda=False,
-    transform_target_type=None,
-):
-    for _, (data, target) in zip(maybe_range(max_batch_per_epoch), dataloader):
-
-        data = convert_dtype(dtype, data)
-        if transform_target_type:
-            target = convert_dtype(dtype, target)
-
-        if use_cuda:
-            data, target = data.cuda(), target.cuda()
-
-        yield data, target
-
-
-def maybe_cuda(module, use_cuda):
-    if use_cuda:
-        module.cuda()
-    return module

--- a/mlbench_core/utils/tracker.py
+++ b/mlbench_core/utils/tracker.py
@@ -3,6 +3,9 @@ from collections import defaultdict
 
 from .log_metrics import LogMetrics
 
+_DEFAULT_COMM_STEPS = ["opt_step"]
+_DEFAULT_COMPUTE_STEPS = ["fwd_pass", "comp_loss", "backprop"]
+
 
 class AverageMeter(object):
     """Computes and stores the average and current value."""
@@ -42,8 +45,8 @@ class Tracker(object):
         run_id,
         rank,
         goal=None,
-        communication_steps=["opt_step"],
-        compute_steps=["fwd_pass", "comp_loss", "backprop"],
+        communication_steps=None,
+        compute_steps=None,
     ):
         self.batch_times = []
         self.validation_times = []
@@ -76,10 +79,16 @@ class Tracker(object):
 
         self.primary_metric = metrics[0]
 
+        if communication_steps is None:
+            communication_steps = _DEFAULT_COMM_STEPS
+
         if not isinstance(communication_steps, list):
             communication_steps = [communication_steps]
 
         self.communication_steps = communication_steps
+
+        if compute_steps is None:
+            compute_steps = _DEFAULT_COMPUTE_STEPS
 
         if not isinstance(compute_steps, list):
             compute_steps = [compute_steps]
@@ -338,3 +347,23 @@ class Tracker(object):
         )
 
         return " | ".join(str_builder)
+
+    def record_batch_init(self):
+        """Records the time taken for initializing batch"""
+        self.record_batch_step("init")
+
+    def record_batch_fwd_pass(self):
+        """Records time taken for forward pass"""
+        self.record_batch_step("fwd_pass")
+
+    def record_batch_comp_loss(self):
+        """Records time taken for loss computation"""
+        self.record_batch_step("comp_loss")
+
+    def record_batch_backprop(self):
+        """Record time taken for backpropagation"""
+        self.record_batch_step("backprop")
+
+    def record_batch_opt_step(self):
+        """Records time taken for optimization"""
+        self.record_batch_step("opt_step")

--- a/tests/test_controlflow_pytorch.py
+++ b/tests/test_controlflow_pytorch.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """Tests for `mlbench_core.controlflow.pytorch` package."""
-
+import itertools
 import random
 
 import pytest
@@ -11,6 +11,11 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.utils.data import DataLoader
 
+from mlbench_core.controlflow.pytorch.helpers import (
+    convert_dtype,
+    iterate_dataloader,
+    maybe_range,
+)
 from mlbench_core.controlflow.pytorch.train_validation import TrainValidation
 from mlbench_core.evaluation.pytorch.metrics import TopKAccuracy
 from mlbench_core.lr_scheduler.pytorch import multistep_learning_rates_with_warmup
@@ -123,3 +128,56 @@ def test_training(mocker, model, optimizer, loss_function, metrics, scheduler):
     assert tv.tracker.current_epoch == 10
     assert tv.tracker.best_epoch > -1
     assert tv.tracker.best_metric_value > 50.0
+
+
+def test_maybe_range():
+    r = maybe_range(10)
+
+    assert len(r) == 10
+    assert r == range(10)
+
+    r = maybe_range(None)
+
+    assert isinstance(r, itertools.count)
+    assert next(r) == 0
+    assert next(r) == 1
+
+
+def test_convert_dtype():
+    t = torch.IntTensor([0])
+
+    tt = convert_dtype("fp32", t)
+
+    assert tt.dtype == torch.float32
+
+    tt2 = convert_dtype("fp64", t)
+
+    assert tt2.dtype == torch.float64
+
+    with pytest.raises(NotImplementedError):
+        tt3 = convert_dtype("int", t)
+
+
+def test_iterate_dataloader(mocker):
+    dataloader = [
+        (torch.IntTensor([0]), torch.IntTensor([1])),
+        (torch.IntTensor([2]), torch.IntTensor([3])),
+    ]
+
+    it = iterate_dataloader(
+        dataloader, "fp32", max_batch_per_epoch=2, transform_target_type=True
+    )
+
+    first = next(it)
+
+    assert first[0].dtype == torch.float32
+    assert first[1].dtype == torch.float32
+    assert first[0].data.item() == 0.0
+    assert first[1].item() == 1.0
+
+    second = next(it)
+
+    assert second[0].dtype == torch.float32
+    assert second[1].dtype == torch.float32
+    assert second[0].data.item() == 2.0
+    assert second[1].item() == 3.0

--- a/tests/test_controlflow_pytorch.py
+++ b/tests/test_controlflow_pytorch.py
@@ -3,18 +3,17 @@
 
 """Tests for `mlbench_core.controlflow.pytorch` package."""
 
-import pytest
+import random
 
+import pytest
 import torch
 import torch.nn as nn
 import torch.optim as optim
 from torch.utils.data import DataLoader
-import random
 
-from mlbench_core.controlflow.pytorch import TrainValidation
+from mlbench_core.controlflow.pytorch.train_validation import TrainValidation
 from mlbench_core.evaluation.pytorch.metrics import TopKAccuracy
 from mlbench_core.lr_scheduler.pytorch import multistep_learning_rates_with_warmup
-from mlbench_core.utils.pytorch.distributed import AllReduceAggregation
 
 
 @pytest.fixture
@@ -52,7 +51,7 @@ def scheduler(optimizer):
 
 
 def test_instantiation(mocker, model, optimizer, loss_function, metrics, scheduler):
-    mocker.patch("mlbench_core.controlflow.pytorch.controlflow.dist")
+    mocker.patch("mlbench_core.controlflow.pytorch.train_validation.dist")
 
     batch_size = 2
 
@@ -74,7 +73,7 @@ def test_instantiation(mocker, model, optimizer, loss_function, metrics, schedul
 
 
 def test_training(mocker, model, optimizer, loss_function, metrics, scheduler):
-    mocker.patch("mlbench_core.controlflow.pytorch.controlflow.dist")
+    mocker.patch("mlbench_core.controlflow.pytorch.train_validation.dist")
     mocker.patch("mlbench_core.utils.pytorch.distributed.dist")
     mocker.patch("mlbench_core.utils.tracker.LogMetrics")
 

--- a/tests/test_helpers_pytorch.py
+++ b/tests/test_helpers_pytorch.py
@@ -3,97 +3,8 @@
 
 """Tests for `mlbench_core.utils.pytorch.helpers` package."""
 
-import pytest
-import time
-import itertools
-import torch
-
-from mlbench_core.utils.pytorch.helpers import (
-    Timeit,
-    maybe_range,
-    update_best_runtime_metric,
-    convert_dtype,
-    config_pytorch,
-    config_path,
-    iterate_dataloader,
-    log_metrics,
-)
-from mlbench_core.utils import Tracker, LogMetrics
-from mlbench_core.evaluation.pytorch.metrics import TopKAccuracy
-
-
-def test_timeit():
-    timeit = Timeit()
-
-    cumu = timeit.cumu
-
-    time.sleep(0.1)
-    timeit.pause()
-    new_cumu = timeit.cumu
-
-    assert new_cumu - cumu - 0.1 < 0.01
-
-    time.sleep(0.1)
-    newer_cumu = timeit.cumu
-
-    assert new_cumu == newer_cumu
-
-    timeit.resume()
-    time.sleep(0.1)
-    timeit.pause()
-
-    last_cumu = timeit.cumu
-
-    assert last_cumu - newer_cumu - 0.1 < 0.01
-    assert last_cumu - cumu - 0.3 < 0.01
-
-
-def test_maybe_range():
-    r = maybe_range(10)
-
-    assert len(r) == 10
-    assert r == range(10)
-
-    r = maybe_range(None)
-
-    assert isinstance(r, itertools.count)
-    assert next(r) == 0
-    assert next(r) == 1
-
-
-def test_update_best_runtime_metric(mocker):
-    tracker = Tracker([TopKAccuracy(5)], 1, 0)
-    # tracker = mocker.patch('mlbench_core.utils.pytorch.helpers.Tracker')
-
-    is_best, best_metric_name = update_best_runtime_metric(tracker, 10.0, "prec")
-
-    assert is_best
-    assert best_metric_name == "best_prec"
-
-    is_best, best_metric_name = update_best_runtime_metric(tracker, 11.0, "prec")
-
-    assert is_best
-    assert best_metric_name == "best_prec"
-
-    is_best, best_metric_name = update_best_runtime_metric(tracker, 9.0, "prec")
-
-    assert not is_best
-    assert best_metric_name == "best_prec"
-
-
-def test_convert_dtype():
-    t = torch.IntTensor([0])
-
-    tt = convert_dtype("fp32", t)
-
-    assert tt.dtype == torch.float32
-
-    tt2 = convert_dtype("fp64", t)
-
-    assert tt2.dtype == torch.float64
-
-    with pytest.raises(NotImplementedError):
-        tt3 = convert_dtype("int", t)
+from mlbench_core.utils import LogMetrics
+from mlbench_core.utils.pytorch.helpers import config_path, config_pytorch
 
 
 def test_config_pytorch(mocker):
@@ -111,23 +22,13 @@ def test_config_pytorch(mocker):
 
 
 def test_LogMetrics(mocker):
-    mocker.patch("mlbench_core.utils.pytorch.helpers.ApiClient")
+    mocker.patch("mlbench_core.api.ApiClient")
 
     LogMetrics.log("1", 1, 1, "loss", 123)
 
     mocker.patch.dict("os.environ", {"MLBENCH_IN_DOCKER": "True"})
 
     LogMetrics.log("1", 1, 1, "loss", 123)
-
-
-def test_log_metrics(mocker):
-    mocker.patch("mlbench_core.utils.pytorch.helpers.ApiClient")
-
-    log_metrics("1", 1, 1, "loss", 123)
-
-    mocker.patch.dict("os.environ", {"MLBENCH_IN_DOCKER": "True"})
-
-    log_metrics("1", 1, 1, "loss", 123)
 
 
 def test_config_path(mocker):
@@ -143,28 +44,3 @@ def test_config_path(mocker):
 
     assert sh.call_count == 1
     assert osmk.call_count == 2
-
-
-def test_iterate_dataloader(mocker):
-    dataloader = [
-        (torch.IntTensor([0]), torch.IntTensor([1])),
-        (torch.IntTensor([2]), torch.IntTensor([3])),
-    ]
-
-    it = iterate_dataloader(
-        dataloader, "fp32", max_batch_per_epoch=2, transform_target_type=True
-    )
-
-    first = next(it)
-
-    assert first[0].dtype == torch.float32
-    assert first[1].dtype == torch.float32
-    assert first[0].data.item() == 0.0
-    assert first[1].item() == 1.0
-
-    second = next(it)
-
-    assert second[0].dtype == torch.float32
-    assert second[1].dtype == torch.float32
-    assert second[0].data.item() == 2.0
-    assert second[1].item() == 3.0


### PR DESCRIPTION
This PR applies the requested change to have the `train_round` function more explicit in the benchmark tasks. The changes are the following:
1. Remove the `train_round` function from `controlflow`
2. Move all helper functions that are only used in the controlflow to `mlbench_core/controlflow/pytorch/helpers.py` (most were previously in `mlbench_core/utils/pytorch/helpers`)
3. Move the now deprecated `TrainValidation` class to a module on its own.
4. Adds functions to the `Tracker` so that we don't need to pass strings anymore for training steps.
5. Remove some unused/deprecated classes/functions

The `train_round` logic is now implemented in each task separately in [#46](https://github.com/mlbench/mlbench-benchmarks/pull/46)