### PR TITLE
Introduce isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,13 @@ repos:
     hooks:
       - id: black
         language_version: python3.7
+
+  - repo: https://github.com/asottile/seed-isort-config
+    rev: v2.1.1
+    hooks:
+      - id: seed-isort-config
+
+  - repo: https://github.com/timothycrosley/isort
+    rev: 4.3.21
+    hooks:
+      - id: isort

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: python
 matrix:
   include:
     - python: 3.6
-      env: TOXENV=black
+      env: TOXENV=lint
     - python: 3.6
       env: TOXENV=py36
     - python: 3.7

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,9 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr htmlcov/
 	rm -fr .pytest_cache
 
-lint: ## check style with flake8
-	flake8 --max-line-length=120 mlbench_core tests
+lint: ## check style with black, sort imports
+	black --check .
+	isort --check-only --recursive .
 
 test: ## run tests quickly with the default Python
 	py.test

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,16 +5,13 @@
 # Imports
 #
 
-import sys
 import os
-
-from os.path import abspath, join, dirname
+import sys
+from os.path import abspath, dirname, join
+from unittest.mock import MagicMock
 
 sys.path.insert(0, abspath(join(dirname(__file__), ".")))
 sys.path.insert(0, abspath(join(dirname(__file__), "..")))
-
-import sys
-from unittest.mock import MagicMock
 
 
 class Mock(MagicMock):
@@ -167,12 +164,12 @@ epub_exclude_files = ["search.html"]
 
 # -- Custom Document processing ----------------------------------------------
 
-import gensidebar
+import gensidebar  # isort:skip
 
 gensidebar.generate_sidebar(globals(), "mlbench_core")
 
-import sphinx.addnodes
-import docutils.nodes
+import sphinx.addnodes  # isort:skip
+import docutils.nodes  # isort:skip
 
 
 def process_child(node):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,7 @@ import os
 
 from os.path import abspath, join, dirname
 
-sys.path.insert(0, abspath(join(dirname(__file__), '.')))
+sys.path.insert(0, abspath(join(dirname(__file__), ".")))
 sys.path.insert(0, abspath(join(dirname(__file__), "..")))
 
 import sys
@@ -65,10 +65,10 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinxcontrib.napoleon",
     "sphinxcontrib.bibtex",
-    'autoapi.extension',
+    "autoapi.extension",
 ]
 
-autoapi_dirs = ['../mlbench_core']
+autoapi_dirs = ["../mlbench_core"]
 autoapi_generate_api_docs = False
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/gensidebar.py
+++ b/docs/gensidebar.py
@@ -5,6 +5,7 @@
 
 import os
 
+
 def write_if_changed(fname, contents):
 
     try:

--- a/mlbench_core/__init__.py
+++ b/mlbench_core/__init__.py
@@ -5,11 +5,4 @@
 __version__ = "2.4.0-dev158"
 
 
-from . import api
-from . import controlflow
-from . import dataset
-from . import evaluation
-from . import lr_scheduler
-from . import models
-from . import optim
-from . import utils
+from . import api, controlflow, dataset, evaluation, lr_scheduler, models, optim, utils

--- a/mlbench_core/api.py
+++ b/mlbench_core/api.py
@@ -3,8 +3,9 @@
 import concurrent.futures
 import datetime
 import logging
-from kubernetes import client, config
+
 import requests
+from kubernetes import client, config
 
 MLBENCH_BACKENDS = ["MPI", "GLOO", "NCCL"]
 

--- a/mlbench_core/cli/__init__.py
+++ b/mlbench_core/cli/__init__.py
@@ -4,5 +4,4 @@
 
 from .cli import cli_group
 
-
 __all__ = ["cli_group"]

--- a/mlbench_core/cli/cli.py
+++ b/mlbench_core/cli/cli.py
@@ -4,24 +4,24 @@
 import configparser
 import json
 import os
+import pickle
 import subprocess
 import sys
+from pathlib import Path
 from time import sleep
-import urllib3
 from urllib import request
 
 import click
+import urllib3
 import yaml
 from appdirs import user_data_dir
 from kubernetes import client
-import mlbench_core
-from mlbench_core.api import ApiClient, MLBENCH_IMAGES, MLBENCH_BACKENDS
 from pyhelm.chartbuilder import ChartBuilder
 from pyhelm.tiller import Tiller
 from tabulate import tabulate
-import pickle
-from pathlib import Path
 
+import mlbench_core
+from mlbench_core.api import MLBENCH_BACKENDS, MLBENCH_IMAGES, ApiClient
 
 GCLOUD_NVIDIA_DAEMONSET = (
     "https://raw.githubusercontent.com/"

--- a/mlbench_core/dataset/__init__.py
+++ b/mlbench_core/dataset/__init__.py
@@ -1,4 +1,1 @@
-from . import imagerecognition
-from . import linearmodels
-from . import nlp
-from . import util
+from . import imagerecognition, linearmodels, nlp, util

--- a/mlbench_core/dataset/imagerecognition/tensorflow/cifar10.py
+++ b/mlbench_core/dataset/imagerecognition/tensorflow/cifar10.py
@@ -6,8 +6,9 @@ import logging
 import os
 import sys
 import tarfile
-from six.moves import urllib, xrange
+
 import tensorflow as tf
+from six.moves import urllib, xrange
 
 
 class DatasetCifar(object):

--- a/mlbench_core/dataset/linearmodels/pytorch/dataloader.py
+++ b/mlbench_core/dataset/linearmodels/pytorch/dataloader.py
@@ -7,8 +7,9 @@ import lmdb
 import numpy as np
 import torch.utils.data
 from PIL import Image
-from mlbench_core.dataset.util.tools import progress_download
 from tensorpack.utils.compatible_serialize import loads
+
+from mlbench_core.dataset.util.tools import progress_download
 
 _logger = logging.getLogger("mlbench")
 

--- a/mlbench_core/dataset/nlp/pytorch/__init__.py
+++ b/mlbench_core/dataset/nlp/pytorch/__init__.py
@@ -1,3 +1,3 @@
-from .dataloader import Wikitext2
 from .bpttwikitext2_dataset import BPTTWikiText2
+from .dataloader import Wikitext2
 from .wmt14_dataset import WMT14Dataset, build_collate_fn

--- a/mlbench_core/dataset/util/pytorch/__init__.py
+++ b/mlbench_core/dataset/util/pytorch/__init__.py
@@ -1,6 +1,6 @@
 from .partition import (
+    DataPartitioner,
     Partition,
     Partitioner,
-    DataPartitioner,
     partition_dataset_by_rank,
 )

--- a/mlbench_core/dataset/util/pytorch/libsvm.py
+++ b/mlbench_core/dataset/util/pytorch/libsvm.py
@@ -8,10 +8,10 @@ https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/binary.html
 import os
 
 import click
+from sklearn.datasets import load_svmlight_file, make_classification
+from tensorpack.dataflow import LMDBSerializer, PrefetchDataZMQ
+
 from mlbench_core.dataset.util.tools import maybe_download_and_extract_bz2
-from sklearn.datasets import load_svmlight_file
-from sklearn.datasets import make_classification
-from tensorpack.dataflow import PrefetchDataZMQ, LMDBSerializer
 
 _DATASET_MAP = {
     "australian_train": {

--- a/mlbench_core/dataset/util/pytorch/partition.py
+++ b/mlbench_core/dataset/util/pytorch/partition.py
@@ -1,7 +1,7 @@
 r"""Partition PyTorch datasets."""
 # -*- coding: utf-8 -*-
-import random
 import logging
+import random
 
 import numpy as np
 import torch

--- a/mlbench_core/evaluation/pytorch/criterion.py
+++ b/mlbench_core/evaluation/pytorch/criterion.py
@@ -1,9 +1,9 @@
 """Customized Loss Functions."""
 
-import torch.nn.functional as F
-from torch.nn.modules.loss import _WeightedLoss
-from torch import nn
 import torch
+import torch.nn.functional as F
+from torch import nn
+from torch.nn.modules.loss import _WeightedLoss
 
 
 class BCELossRegularized(_WeightedLoss):

--- a/mlbench_core/evaluation/pytorch/metrics.py
+++ b/mlbench_core/evaluation/pytorch/metrics.py
@@ -3,6 +3,7 @@
 from abc import abstractmethod
 
 import torch
+
 from mlbench_core.utils import AverageMeter
 from mlbench_core.utils.pytorch.distributed import global_average
 

--- a/mlbench_core/lr_scheduler/pytorch/__init__.py
+++ b/mlbench_core/lr_scheduler/pytorch/__init__.py
@@ -2,9 +2,9 @@
 """
 
 from .lr import (
-    triangular_learning_rates,
-    cyclical_learning_rates,
-    multistep_learning_rates_with_warmup,
     SQRTTimeDecayLR,
     TimeDecayLR,
+    cyclical_learning_rates,
+    multistep_learning_rates_with_warmup,
+    triangular_learning_rates,
 )

--- a/mlbench_core/models/pytorch/__init__.py
+++ b/mlbench_core/models/pytorch/__init__.py
@@ -1,3 +1,1 @@
-from . import resnet
-from . import linear_models
-from . import nlp
+from . import linear_models, nlp, resnet

--- a/mlbench_core/models/pytorch/resnet.py
+++ b/mlbench_core/models/pytorch/resnet.py
@@ -22,12 +22,11 @@ for image net. Here we only implemented the remaining models
 for CIFAR-10 dataset. Besides, their implementation uses projection shortcut by default.
 
 """
-from mlbench_core.controlflow.pytorch.helpers import convert_dtype
-
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
 
+from mlbench_core.controlflow.pytorch.helpers import convert_dtype
 
 _DEFAULT_RESNETCIFAR_VERSION = 1
 

--- a/mlbench_core/models/pytorch/vgg.py
+++ b/mlbench_core/models/pytorch/vgg.py
@@ -4,7 +4,6 @@ From https://github.com/kuangliu/pytorch-cifar."""
 import torch
 import torch.nn as nn
 
-
 cfg = {
     "VGG11": [64, "M", 128, "M", 256, 256, "M", 512, 512, "M", 512, 512, "M"],
     "VGG13": [64, 64, "M", 128, 128, "M", 256, 256, "M", 512, 512, "M", 512, 512, "M"],

--- a/mlbench_core/models/tensorflow/resnet_model.py
+++ b/mlbench_core/models/tensorflow/resnet_model.py
@@ -20,9 +20,7 @@ The key difference of the full preactivation 'v2' variant compared to the
 rather than after.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import tensorflow as tf
 

--- a/mlbench_core/optim/pytorch/fp_optimizers.py
+++ b/mlbench_core/optim/pytorch/fp_optimizers.py
@@ -4,11 +4,12 @@ import math
 
 import torch
 import torch.distributed as dist
-from mlbench_core.utils.pytorch.distributed import (
-    AllReduceAggregationHVD,
-    AllReduceAggregation,
-)
 from torch.nn.utils import clip_grad_norm_
+
+from mlbench_core.utils.pytorch.distributed import (
+    AllReduceAggregation,
+    AllReduceAggregationHVD,
+)
 
 try:
     from apex.optimizers import FusedAdam

--- a/mlbench_core/optim/pytorch/optim.py
+++ b/mlbench_core/optim/pytorch/optim.py
@@ -1,15 +1,14 @@
+import numpy as np
+import torch
+import torch.distributed as dist
+from torch.optim import SGD, Adam
+from torch.optim.optimizer import Optimizer, required
+
 from mlbench_core.utils.pytorch.distributed import (
     AllReduceAggregation,
     DecentralizedAggregation,
     PowerAggregation,
 )
-import numpy as np
-import torch
-import torch.distributed as dist
-from mlbench_core.utils.pytorch.distributed import AllReduceAggregation
-from mlbench_core.utils.pytorch.distributed import DecentralizedAggregation
-from torch.optim import SGD, Adam
-from torch.optim.optimizer import Optimizer, required
 
 
 class SparsifiedSGD(Optimizer):

--- a/mlbench_core/utils/__init__.py
+++ b/mlbench_core/utils/__init__.py
@@ -1,5 +1,5 @@
-from .tracker import AverageMeter, Tracker
 from .log_metrics import LogMetrics
+from .tracker import AverageMeter, Tracker
 
 try:
     import torch

--- a/mlbench_core/utils/pytorch/checkpoint.py
+++ b/mlbench_core/utils/pytorch/checkpoint.py
@@ -2,6 +2,7 @@ import enum
 import json
 import os
 import shutil
+
 import dill
 import torch
 

--- a/mlbench_core/utils/pytorch/distributed.py
+++ b/mlbench_core/utils/pytorch/distributed.py
@@ -1,6 +1,7 @@
+import numpy as np
 import torch
 import torch.distributed as dist
-import numpy as np
+
 from mlbench_core.utils.pytorch.utils import orthogonalize
 
 try:

--- a/mlbench_core/utils/pytorch/topology.py
+++ b/mlbench_core/utils/pytorch/topology.py
@@ -1,6 +1,8 @@
 import socket
+
 import torch
 import torch.distributed as dist
+
 from mlbench_core.utils.pytorch.distributed import get_backend_tensor
 
 

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,5 @@ setup(
     extras_require=extras,
     url="https://github.com/mlbench/mlbench_core",
     version="2.4.0-dev158",
-
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ test_requirements = [
     "freezegun==0.3.12",
     "black==19.10b0",
     "pytest-black==0.3.8",
+    "isort==4.3.21",
     "pre-commit",
     "coverage",
 ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,8 +3,9 @@
 
 """Tests for `mlbench_core.api` package."""
 
-import pytest
 import datetime
+
+import pytest
 
 from mlbench_core.api import ApiClient
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,8 +5,9 @@
 
 import pytest
 from click.testing import CliRunner
-from mlbench_core.cli import cli_group
 from google.auth.exceptions import DefaultCredentialsError
+
+from mlbench_core.cli import cli_group
 
 ########################## GLOBALS #################################
 

--- a/tests/test_pytorch_distributed.py
+++ b/tests/test_pytorch_distributed.py
@@ -1,5 +1,6 @@
 """Tests for `mlbench_core.utils.pytorch.distributed`"""
 import torch
+
 from mlbench_core.utils.pytorch.distributed import pack_tensors, unpack_tensors
 
 

--- a/tests/test_pytorch_metrics.py
+++ b/tests/test_pytorch_metrics.py
@@ -1,6 +1,7 @@
-import torch
-from mlbench_core.evaluation.pytorch.metrics import F1Score, TopKAccuracy
 import numpy as np
+import torch
+
+from mlbench_core.evaluation.pytorch.metrics import F1Score, TopKAccuracy
 
 
 def test_f1_score():

--- a/tests/test_pytorch_models.py
+++ b/tests/test_pytorch_models.py
@@ -1,9 +1,8 @@
 import pytest
-
 import torch
 
-from mlbench_core.models.pytorch.resnet import *
 from mlbench_core.models.pytorch.linear_models import *
+from mlbench_core.models.pytorch.resnet import *
 
 
 def test_resnet18():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -115,6 +115,3 @@ def test_orthogonalize():
 
     # check if m'*m = I
     assert torch.allclose(torch.matmul(m.t(), m), identity, atol=1e-04)
-
-
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,11 +5,12 @@
 
 import datetime
 
+import torch
 from freezegun import freeze_time
+
 from mlbench_core.evaluation.goals import task1_time_to_accuracy_light_goal
 from mlbench_core.evaluation.pytorch.metrics import TopKAccuracy
 from mlbench_core.utils import Tracker
-import torch
 from mlbench_core.utils.pytorch.utils import orthogonalize
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist =  py36, py37, black
+envlist =  py36, py37, lint
 
 [default]
 basepython = python3.6
@@ -34,9 +34,9 @@ commands =
     py.test --basetemp={envtmpdir}
 
 
-[testenv:black]
+[testenv:lint]
 
-description = run Black (linter)
+description = run Black (linter) and isort (import sorter)
 
 basepython = {[default]basepython}
 
@@ -44,9 +44,19 @@ skip_install = True
 
 deps =
     black
+    isort
 
 setenv =
     BLACK_LINT_ARGS=--check
 
 commands =
-    black {env:BLACK_LINT_ARGS:} mlbench_core
+    black {env:BLACK_LINT_ARGS:} .
+    isort --check-only --recursive .
+
+[tool:isort]
+; black's default line length
+line_length = 88
+multi_line_output = 3
+include_trailing_comma = True
+known_first_party = mlbench_core
+known_third_party =PIL,appdirs,click,cv2,deprecation,dill,docutils,freezegun,gensidebar,kubernetes,lmdb,numpy,pyhelm,pytest,requests,setuptools,six,sklearn,spacy,sphinx,tabulate,tensorflow,tensorpack,torch,torchtext,torchvision,urllib3,yaml

--- a/tox.ini
+++ b/tox.ini
@@ -59,4 +59,4 @@ line_length = 88
 multi_line_output = 3
 include_trailing_comma = True
 known_first_party = mlbench_core
-known_third_party =PIL,appdirs,click,cv2,deprecation,dill,docutils,freezegun,gensidebar,kubernetes,lmdb,numpy,pyhelm,pytest,requests,setuptools,six,sklearn,spacy,sphinx,tabulate,tensorflow,tensorpack,torch,torchtext,torchvision,urllib3,yaml
+known_third_party =PIL,appdirs,click,cv2,deprecation,dill,docutils,freezegun,gensidebar,google,kubernetes,lmdb,numpy,pyhelm,pytest,requests,sacremoses,setuptools,six,sklearn,sphinx,subword_nmt,tabulate,tensorflow,tensorpack,torch,torchtext,torchvision,urllib3,yaml

--- a/travis-requirements.txt
+++ b/travis-requirements.txt
@@ -2,3 +2,4 @@ pytest-mock==1.10.0
 freezegun==0.3.12
 black==19.10b0
 pytest-black==0.3.8
+isort==4.3.21


### PR DESCRIPTION
First attempt to introduce `isort`. I had to fight a bit with the pre-commit hooks, hence the usage of `seed-isort-config`, see the following for some background:

https://github.com/pre-commit/mirrors-isort/issues/4
https://github.com/pre-commit/mirrors-isort#classification-of-imports
https://github.com/asottile/seed-isort-config#usage-with-pre-commit

The last commit applies the `isort` import reordering according to the config I selected; this is subject of course to your preferences. :)