### PR TITLE
Pytorch 1.5

### DIFF
--- a/mlbench_core/__init__.py
+++ b/mlbench_core/__init__.py
@@ -2,7 +2,7 @@
 
 """Top-level package for mlbench_core."""
 
-__version__ = "2.4.0"
+__version__ = "2.4.0-dev158"
 
 from . import api
 from . import controlflow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 kubernetes==9.0.0
-torch==1.4.0
+torch==1.5.0
 torchvision==0.5.0
 tensorflow==1.13.2
 dill==0.2.8.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.4.0
+current_version = 2.4.0-dev158
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-dev(?P<dev>[0-9]+))?
 serialize = 
 	{major}.{minor}.{patch}-dev{dev}

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/mlbench/mlbench_core",
-    version="2.4.0",
+    version="2.4.0-dev158",
     zip_safe=False,
 )


### PR DESCRIPTION
Linked to this PR https://github.com/mlbench/mlbench-benchmarks/pull/48.

(I guess version changes with `-dev158` are not final, but the change in `requirements.txt` is necessary)