### PR TITLE
Catch exceptions when creating/deleting clusters

### DIFF
--- a/mlbench_core/cli/cli.py
+++ b/mlbench_core/cli/cli.py
@@ -393,9 +393,11 @@ def delete_gcloud(name, zone, project):
         click.echo("Exception from Google:")
         print(e)
         click.echo("Double-check your project, zone and cluster name")
-        click.echo("Try running 'gcloud container clusters list' to list all active clusters")
+        click.echo(
+            "Try running 'gcloud container clusters list' to list all active clusters"
+        )
         sys.exit(1)
-    
+
     # wait for operation to complete
     while response.status < response.DONE:
         response = gclient.get_operation(
@@ -528,10 +530,14 @@ def create_gcloud(
     except AlreadyExists as e:
         click.echo("Exception from Google:")
         print(e)
-        click.echo("A cluster with this name already exists in the specified project and zone")
-        click.echo("Try running 'gcloud container clusters list' to list all active clusters")
+        click.echo(
+            "A cluster with this name already exists in the specified project and zone"
+        )
+        click.echo(
+            "Try running 'gcloud container clusters list' to list all active clusters"
+        )
         sys.exit(1)
-        
+
     # wait for cluster to load
     while response.status < response.DONE:
         response = gclient.get_operation(


### PR DESCRIPTION
Catches exceptions when deleting or creating clusters and tells user to run `gcloud container clusters list`. This addresses the strange behavior described in #94, which seems to be an issue with Gcloud and not MLBench.

(I tried to add tests for this in `tests/test_cli.py` but for some reason I couldn't get pytest to recognize the `sys.exit`...)