### PR TITLE
Downgrade Sphinx

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx==3.1.1
+Sphinx==3.0.4
 sphinx-rtd-theme==0.5.0
 sphinxcontrib-napoleon==0.7
 sphinxcontrib-bibtex==1.0.0


### PR DESCRIPTION
Downgrades Sphinx since 3.1.1 does not work with AutoAPI